### PR TITLE
Reduced Docker image size by using alpine as base

### DIFF
--- a/crossdock/Dockerfile
+++ b/crossdock/Dockerfile
@@ -1,5 +1,7 @@
-FROM python:2.7
+FROM alpine
 
+RUN apk update
+RUN apk add python sqlite sqlite-libs py-pip gcc python-dev musl-dev libffi-dev openssl-dev
 ENV APPDIR /usr/src/app/
 RUN mkdir -p ${APPDIR}
 WORKDIR ${APPDIR}


### PR DESCRIPTION
Signed-off-by: Ishan Jain <ishanjain28@gmail.com>

Here are the steps I took to reduce image size: 
1. Removed python2.7 image and replaced it with alpine.
2. Added only the  packages required to run the program. 

I also tried to take more steps to reduce image size but they didn't worked well, So I removed those. 
1. I tried to remove `gcc` and `py-pip` after all deps are installed and right before starting the application which resulted in errors. 

This Pull request resolves #88 