### PR TITLE
[Experiment] support dual Thrift versions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,8 +3,8 @@ branch = True
 
 [report]
 omit = 
-  jaeger_client/thrift_gen/*
-  jaeger_client/thrift_gen/*/*
+  jaeger_client/thrift_gen*/*
+  jaeger_client/thrift_gen*/*/*
   crossdock/thrift_gen/*
 
 [xml]


### PR DESCRIPTION
In order to support Python 3 we need to use `thrift>=0.10.0`, but many existing applications depend on `thrift==0.9.3`. The proposed compromise is to generate source files using both Thrift versions (this PR), and then change the client to dynamically switch between one of the dirs, either by sniffing which version of `thrift` is installed (might be difficult, the module does not contain the `__version__` attribute), or by making it a configuration parameter (defaulted to 0.9.3 in Python 2, and to 0.10.0 in Python 3).