### PR TITLE
Make xdock-java depend on jaeger-agent

### DIFF
--- a/crossdock/docker-compose.yml
+++ b/crossdock/docker-compose.yml
@@ -38,6 +38,8 @@ services:
 
     java:
         image: jaegertracing/xdock-java
+        depends_on:
+            - jaeger-agent
         ports:
             - "8080-8082"
 


### PR DESCRIPTION
The xdock-java container exists immediately with the error:

```
Exception in thread "main" java.lang.RuntimeException: TUDPTransport cannot connect:
	at com.uber.jaeger.reporters.protocols.ThriftUdpTransport.newThriftUdpClient(ThriftUdpTransport.java:49)
	at com.uber.jaeger.senders.UdpSender.<init>(UdpSender.java:46)
	at com.uber.jaeger.crossdock.JerseyServer.senderFromEnv(JerseyServer.java:165)
	at com.uber.jaeger.crossdock.JerseyServer.main(JerseyServer.java:142)
Caused by: java.net.SocketException: Unresolved address
	at java.net.DatagramSocket.connect(DatagramSocket.java:493)
	at com.uber.jaeger.reporters.protocols.ThriftUdpTransport.newThriftUdpClient(ThriftUdpTransport.java:47)
	... 3 more
```
It actually wants to connect to jaeger-client, according to strace:
```
[pid 28925] sendto(8, "\2\0\0\0\16\0\0\0\r\0\0\0jaeger-agent\0", 25, MSG_NOSIGNAL, NULL, 0) = 25
```
This patch tries to make jaeger-agent spawn before xdock-java