### PR TITLE
fix(python3): add support. skindeep changes for #59

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,8 @@ thrift: idl-submodule thrift-image
 	${THRIFT} -o /data --gen py:${THRIFT_PY_ARGS} -out /data/$(THRIFT_GEN_DIR) /data/idl/thrift/zipkinCore.thrift
 	${THRIFT} -o /data --gen py:${THRIFT_PY_ARGS} -out /data/$(THRIFT_GEN_DIR) /data/idl/thrift/agent.thrift
 	${THRIFT} -o /data --gen py:${THRIFT_PY_ARGS} -out /data/$(THRIFT_GEN_DIR) /data/idl/thrift/sampling.thrift
+	find jaeger_client/thrift_gen -iname '*.py' -exec sed -i.bak 's/from ttype/from .ttype/g' {} \;
+	rm jaeger_client/thrift_gen/{**/*.bak,*.bak}
 	rm -rf ${THRIFT_GEN_DIR}/*/*-remote
 
 update-license:

--- a/crossdock/thrift_gen/tracetest/TracedService.py
+++ b/crossdock/thrift_gen/tracetest/TracedService.py
@@ -8,7 +8,7 @@
 
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException
 import logging
-from ttypes import *
+from .ttypes import *
 from thrift.Thrift import TProcessor
 from thrift.transport import TTransport
 from thrift.protocol import TBinaryProtocol, TProtocol

--- a/crossdock/thrift_gen/tracetest/constants.py
+++ b/crossdock/thrift_gen/tracetest/constants.py
@@ -7,5 +7,5 @@
 #
 
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException
-from ttypes import *
+from .ttypes import *
 

--- a/jaeger_client/thrift.py
+++ b/jaeger_client/thrift.py
@@ -58,6 +58,8 @@ def port_to_int(port):
 
 
 def id_to_int(big_id):
+    if big_id is None:
+        return None
     # zipkincore.thrift defines ID fields as i64, which is signed,
     # therefore we convert large IDs (> 2^63) to negative longs
     if big_id > _max_signed_id:

--- a/jaeger_client/thrift_gen/agent/Agent.py
+++ b/jaeger_client/thrift_gen/agent/Agent.py
@@ -8,7 +8,7 @@
 
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException
 import logging
-from ttypes import *
+from .ttypes import *
 from thrift.Thrift import TProcessor
 from thrift.transport import TTransport
 from thrift.protocol import TBinaryProtocol, TProtocol

--- a/jaeger_client/thrift_gen/agent/constants.py
+++ b/jaeger_client/thrift_gen/agent/constants.py
@@ -7,5 +7,5 @@
 #
 
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException
-from ttypes import *
+from .ttypes import *
 

--- a/jaeger_client/thrift_gen/sampling/SamplingManager.py
+++ b/jaeger_client/thrift_gen/sampling/SamplingManager.py
@@ -8,7 +8,7 @@
 
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException
 import logging
-from ttypes import *
+from .ttypes import *
 from thrift.Thrift import TProcessor
 from thrift.transport import TTransport
 from thrift.protocol import TBinaryProtocol, TProtocol

--- a/jaeger_client/thrift_gen/sampling/constants.py
+++ b/jaeger_client/thrift_gen/sampling/constants.py
@@ -7,5 +7,5 @@
 #
 
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException
-from ttypes import *
+from .ttypes import *
 

--- a/jaeger_client/thrift_gen/zipkincore/ZipkinCollector.py
+++ b/jaeger_client/thrift_gen/zipkincore/ZipkinCollector.py
@@ -8,7 +8,7 @@
 
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException
 import logging
-from ttypes import *
+from .ttypes import *
 from thrift.Thrift import TProcessor
 from thrift.transport import TTransport
 from thrift.protocol import TBinaryProtocol, TProtocol

--- a/jaeger_client/thrift_gen/zipkincore/constants.py
+++ b/jaeger_client/thrift_gen/zipkincore/constants.py
@@ -7,7 +7,7 @@
 #
 
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException
-from ttypes import *
+from .ttypes import *
 
 CLIENT_SEND = "cs"
 CLIENT_RECV = "cr"


### PR DESCRIPTION
This has been lightly tested, and will hopefully foster discussion. I'm doing a spike for adding tracing to our team's django app with Jaeger and Python3 .

I'd like to merge this in, but please understand I'm only doing this to get around opentracing-contrib/python-django#7 . I have another PR (to another PR) for that issue:
opentracing-contrib/python-django#6
granduke/python-django#1 (this is the changes I've made to add python3 support and such)