### PR TITLE
Make sure header keys and values are byte strings

### DIFF
--- a/jaeger_client/codecs.py
+++ b/jaeger_client/codecs.py
@@ -70,7 +70,9 @@ class TextCodec(Codec):
                     encoded_value = urllib.parse.quote(value)
                 else:
                     encoded_value = value
-                carrier['%s%s' % (self.baggage_prefix, key)] = encoded_value
+                header_key = '%s%s' % (self.baggage_prefix, key.encode('utf-8'))
+                header_value = encoded_value.encode('utf-8')
+                carrier[header_key] = header_value
 
     def extract(self, carrier):
         if not hasattr(carrier, 'iteritems'):

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -111,7 +111,7 @@ class TestCodecs(unittest.TestCase):
             assert carrier == {'trace-id': '100:7f:0:1'}
 
             ctx._baggage = {
-                'fry': 'Leela',
+                'fry': u'Leela',
                 'bender': 'Countess de la Roca',
             }
             carrier = {}
@@ -126,6 +126,9 @@ class TestCodecs(unittest.TestCase):
                     'trace-id': '100:7f:0:1',
                     'trace-attr-bender': 'Countess de la Roca',
                     'trace-attr-fry': 'Leela'}
+            for key, val in carrier.iteritems():
+                assert isinstance(key, str)
+                assert isinstance(val, str)
 
     def test_context_from_bad_readable_headers(self):
         codec = TextCodec(trace_id_header='Trace_ID',


### PR DESCRIPTION
From an explanation by @yurishkuro:

> So the fundamental issue is that this statement `msg += message_body` in `httplib` does an upgrade of `msg` to Unicode if the rhs is in Unicode. Then later if some ascii string is appended and cannot be decoded as Unicode the whole thing crashes. Note that `message_body` is not actually the HTTP request body, it can be *any* line in the http request, including headers.

> Jaeger currently treats baggage by converting it into headers in this form: `"uberctx-%s: %s" % (key, value)`. I suspect if either key or value contain a Unicode string then the whole header gets upgraded to Unicode and breaks `httplib` due to  `+=` above.

> We may potentially fix it by ensuring that both baggage key and value are encoded into byte strings, via `s.encode('utf-8')`, before creating a header from them.

Signed-off-by: Michael Kolodny <mkolodny@uber.com>