### PR TITLE
Encode unicode baggage keys/values to UTF-8

### DIFF
--- a/jaeger_client/codecs.py
+++ b/jaeger_client/codecs.py
@@ -71,10 +71,9 @@ class TextCodec(Codec):
                     encoded_value = urllib.parse.quote(value)
                     # we assume that self.url_encoding means we are injecting
                     # into HTTP headers. httplib does not like unicode strings
-                    # so we convert them to utf-8.
-                    if isinstance(encoded_value, unicode):
-                        encoded_value = encoded_value.encode('utf-8')
-                    if isinstance(encoded_key, unicode):
+                    # so we convert the key to utf-8. The URL-encoded value is
+                    # already a plain string.
+                    if isinstance(key, unicode):
                         encoded_key = key.encode('utf-8')
                 else:
                     encoded_value = value

--- a/jaeger_client/codecs.py
+++ b/jaeger_client/codecs.py
@@ -71,9 +71,10 @@ class TextCodec(Codec):
                     encoded_value = urllib.parse.quote(value)
                     # we assume that self.url_encoding means we are injecting
                     # into HTTP headers. httplib does not like unicode strings
-                    # so we convert the key to utf-8. We do not need to encode
-                    # the value since it's already URL-encoded.
-                    if isinstance(key, unicode):
+                    # so we convert them to utf-8.
+                    if isinstance(encoded_value, unicode):
+                        encoded_value = encoded_value.encode('utf-8')
+                    if isinstance(encoded_key, unicode):
                         encoded_key = key.encode('utf-8')
                 else:
                     encoded_value = value

--- a/jaeger_client/codecs.py
+++ b/jaeger_client/codecs.py
@@ -66,11 +66,19 @@ class TextCodec(Codec):
         baggage = span_context.baggage
         if baggage:
             for key, value in six.iteritems(baggage):
+                encoded_key = key
                 if self.url_encoding:
                     encoded_value = urllib.parse.quote(value)
+                    # we assume that self.url_encoding means we are injecting
+                    # into HTTP headers. httplib does not like unicode strings
+                    # so we convert the key to utf-8. We do not need to encode
+                    # the value since it's already URL-encoded.
+                    if isinstance(key, unicode):
+                        encoded_key = key.encode('utf-8')
                 else:
                     encoded_value = value
-                carrier['%s%s' % (self.baggage_prefix, key)] = encoded_value
+                header_key = '%s%s' % (self.baggage_prefix, encoded_key)
+                carrier[header_key] = encoded_value
 
     def extract(self, carrier):
         if not hasattr(carrier, 'iteritems'):

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
             'pytest-timeout',
             'pytest-tornado',
             'pytest-benchmark[histogram]>=3.0.0rc1',
+            'pytest-localserver',
             'flake8<3',  # see https://github.com/zheller/flake8-quotes/issues/29
             'flake8-quotes',
             'coveralls',

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 import unittest
 from collections import namedtuple
 import urllib2
+import six
 
 import mock
 import pytest
@@ -122,14 +123,14 @@ class TestCodecs(unittest.TestCase):
                     'trace-id': '100:7f:0:1',
                     'trace-attr-bender': 'Countess%20de%20la%20Roca',
                     'trace-attr-fry': 'Leela'}
+                for key, val in six.iteritems(carrier):
+                    assert isinstance(key, str)
+                    assert isinstance(val, str)
             else:
                 assert carrier == {
                     'trace-id': '100:7f:0:1',
                     'trace-attr-bender': 'Countess de la Roca',
                     'trace-attr-fry': 'Leela'}
-            for key, val in carrier.iteritems():
-                assert isinstance(key, str)
-                assert isinstance(val, str)
 
     def test_context_from_bad_readable_headers(self):
         codec = TextCodec(trace_id_header='Trace_ID',
@@ -326,6 +327,7 @@ def test_debug_id():
 
 
 def test_non_unicode_baggage(httpserver):
+    # httpserver is provided by pytest-localserver
     httpserver.serve_content(content='Hello', code=200, headers=None)
 
     tracer = Tracer(

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -326,7 +326,7 @@ def test_debug_id():
     assert tags[0].value == 'Coraline'
 
 
-def test_non_unicode_baggage(httpserver):
+def test_non_ascii_baggage(httpserver):
     # httpserver is provided by pytest-localserver
     httpserver.serve_content(content='Hello', code=200, headers=None)
 

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -115,6 +115,10 @@ class TestCodecs(unittest.TestCase):
             ctx._baggage = {
                 'fry': u'Leela',
                 'bender': 'Countess de la Roca',
+                b'key1': bytes(chr(255)),
+                u'key2-caf\xe9': 'caf\xc3\xa9',
+                u'key3': u'caf\xe9',
+                'key4-caf\xc3\xa9': 'value',
             }
             carrier = {}
             codec.inject(ctx, carrier)
@@ -122,7 +126,12 @@ class TestCodecs(unittest.TestCase):
                 assert carrier == {
                     'trace-id': '100:7f:0:1',
                     'trace-attr-bender': 'Countess%20de%20la%20Roca',
-                    'trace-attr-fry': 'Leela'}
+                    'trace-attr-fry': 'Leela',
+                    'trace-attr-key1': '%FF',
+                    'trace-attr-key2-caf\xc3\xa9': 'caf%C3%A9',
+                    'trace-attr-key3': 'caf%C3%A9',
+                    'trace-attr-key4-caf\xc3\xa9': 'value',
+                }, 'with url_encoding = %s' % url_encoding
                 for key, val in six.iteritems(carrier):
                     assert isinstance(key, str)
                     assert isinstance(val, str)
@@ -130,7 +139,12 @@ class TestCodecs(unittest.TestCase):
                 assert carrier == {
                     'trace-id': '100:7f:0:1',
                     'trace-attr-bender': 'Countess de la Roca',
-                    'trace-attr-fry': 'Leela'}
+                    'trace-attr-fry': 'Leela',
+                    'trace-attr-key1': '\xff',
+                    u'trace-attr-key2-caf\xe9': 'caf\xc3\xa9',
+                    u'trace-attr-key3': u'caf\xe9',
+                    'trace-attr-key4-caf\xc3\xa9': 'value',
+                }, 'with url_encoding = %s' % url_encoding
 
     def test_context_from_bad_readable_headers(self):
         codec = TextCodec(trace_id_header='Trace_ID',

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -112,7 +112,7 @@ class TestCodecs(unittest.TestCase):
             assert carrier == {'trace-id': '100:7f:0:1'}
 
             ctx._baggage = {
-                'fry': 'Leela',
+                'fry': u'Leela',
                 'bender': 'Countess de la Roca',
             }
             carrier = {}
@@ -127,6 +127,9 @@ class TestCodecs(unittest.TestCase):
                     'trace-id': '100:7f:0:1',
                     'trace-attr-bender': 'Countess de la Roca',
                     'trace-attr-fry': 'Leela'}
+            for key, val in carrier.iteritems():
+                assert isinstance(key, str)
+                assert isinstance(val, str)
 
     def test_context_from_bad_readable_headers(self):
         codec = TextCodec(trace_id_header='Trace_ID',


### PR DESCRIPTION
Replaces #108

There's also an outstanding bug report https://bugs.python.org/issue22231

The original issue is this exception:

```
UnicodeDecodeError: 'ascii' codec can't decode byte 0xb5 in position 295: ordinal not in range(128)
(10 additional frame(s) were not displayed)
...
  File "urllib3/connectionpool.py", line 356, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "python2.7/httplib.py", line 1052, in request
    self._send_request(method, url, body, headers)
  File "python2.7/httplib.py", line 1092, in _send_request
    self.endheaders(body)
  File "python2.7/httplib.py", line 1048, in endheaders
    self._send_output(message_body)
  File "python2.7/httplib.py", line 890, in _send_output
    msg += message_body

UnicodeDecodeError: 'ascii' codec can't decode byte 0xb5 in position 295: ordinal not in range(128)
```