### PR TITLE
Add codec for B3 trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,15 +133,13 @@ This allows using Jaeger UI to find the trace by this tag.
 
 This library internally uses Zipkin Thrift data model and conventions, 
 but if you want to use it directly with other Zipkin libraries & backend, 
-it needs:
-  1. different [wire codecs](./jaeger_client/codecs.py) to transmit 
-     trace context as `X-B3-*` headers
-  2. a reporter that will submit traces to Zipkin backend over Zipkin-supported 
-     transports like Kafka or HTTP
+you can provide the configuration property `propagation: 'b3'` and the
+`X-B3-*` HTTP headers will be supported.
 
-Both of these things are easy to add (e.g. it was done in https://github.com/jaegertracing/jaeger-client-java/pull/34), 
-but it is not a priority for the Uber team since we are using a different backend.
-We will welcome PRs that provide that functionality.
+The B3 codec assumes it will receive lowercase HTTP headers, as this seems
+to be the standard in the popular frameworks like Flask and Django.
+Please make sure your framework does the same.
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -131,8 +131,7 @@ This allows using Jaeger UI to find the trace by this tag.
 
 ## Zipkin Compatibility
 
-This library internally uses Zipkin Thrift data model and conventions, 
-but if you want to use it directly with other Zipkin libraries & backend, 
+To use this library directly with other Zipkin libraries & backend,
 you can provide the configuration property `propagation: 'b3'` and the
 `X-B3-*` HTTP headers will be supported.
 

--- a/jaeger_client/codecs.py
+++ b/jaeger_client/codecs.py
@@ -34,6 +34,9 @@ from .span_context import SpanContext
 import six
 import urllib.parse
 
+SAMPLED_FLAG = 0x01
+DEBUG_FLAG = 0x02
+
 
 class Codec(object):
     def inject(self, span_context, carrier):
@@ -227,6 +230,53 @@ class ZipkinCodec(Codec):
                 flags = getattr(carrier, 'traceflags')
             else:
                 raise InvalidCarrierException('carrier has no traceflags')
+        if not trace_id:
+            return None
+        return SpanContext(trace_id=trace_id, span_id=span_id,
+                           parent_id=parent_id, flags=flags,
+                           baggage=None)
+
+
+def header_to_hex(header):
+    if not isinstance(header, (str, unicode)):
+        return None
+    return int(header, 16)
+
+
+class B3Codec(Codec):
+    """
+    Support B3 header properties
+
+    """
+    def __init__(self):
+        self.trace_header = 'X-B3-TraceId'
+        self.span_header = 'X-B3-SpanId'
+        self.parent_span_header = 'X-B3-ParentSpanId'
+        self.sampled_header = 'X-B3-Sampled'
+        self.flags_header = 'X-B3-Flags'
+
+    def inject(self, span_context, carrier):
+        if not isinstance(carrier, dict):
+            raise InvalidCarrierException('carrier not a dictionary')
+        carrier[self.trace_header] = format(span_context.trace_id, 'x')
+        carrier[self.span_header] = format(span_context.span_id, 'x')
+        if span_context.parent_id is not None:
+            carrier[self.parent_span_header] = format(span_context.parent_id, 'x')
+        carrier[self.flags_header] = str(span_context.flags)
+
+    def extract(self, carrier):
+        if not isinstance(carrier, dict):
+            raise InvalidCarrierException('carrier not a dictionary')
+        trace_id = header_to_hex(carrier.get(self.trace_header.lower()))
+        span_id = header_to_hex(carrier.get(self.span_header.lower()))
+        parent_id = header_to_hex(carrier.get(self.parent_span_header.lower()))
+        flags = 0x00
+        sampled = carrier.get(self.sampled_header.lower())
+        if sampled == '1':
+            flags |= SAMPLED_FLAG
+        debug = carrier.get(self.flags_header.lower())
+        if debug == '1':
+            flags |= DEBUG_FLAG
         if not trace_id:
             return None
         return SpanContext(trace_id=trace_id, span_id=span_id,

--- a/jaeger_client/config.py
+++ b/jaeger_client/config.py
@@ -249,9 +249,9 @@ class Config(object):
         return tags
 
     @property
-    def extra_codecs(self):
-        b3_codec = get_boolean(self.config.get('b3_codec', False), False)
-        if b3_codec:
+    def propagation(self):
+        propagation = self.config.get('propagation', None)
+        if propagation == 'b3':
             # replace the codec with a B3 enabled instance
             return {Format.HTTP_HEADERS: B3Codec()}
         return {}
@@ -318,7 +318,7 @@ class Config(object):
             debug_id_header=self.debug_id_header,
             tags=self.tags,
             max_tag_value_length=self.max_tag_value_length,
-            extra_codecs=self.extra_codecs,
+            extra_codecs=self.propagation,
         )
 
     def _initialize_global_tracer(self, tracer):

--- a/jaeger_client/config.py
+++ b/jaeger_client/config.py
@@ -20,6 +20,7 @@ import os
 import threading
 
 import opentracing
+from opentracing.propagation import Format
 from . import Tracer
 from .local_agent_net import LocalAgentSender
 from .reporter import (
@@ -46,6 +47,7 @@ from .constants import (
 )
 from .metrics import LegacyMetricsFactory, MetricsFactory, Metrics
 from .utils import get_boolean, ErrorReporter
+from .codecs import B3Codec
 
 DEFAULT_REPORTING_HOST = 'localhost'
 DEFAULT_REPORTING_PORT = 6831
@@ -246,6 +248,14 @@ class Config(object):
                 tags[key.strip()] = value.strip()
         return tags
 
+    @property
+    def extra_codecs(self):
+        b3_codec = get_boolean(self.config.get('b3_codec', False), False)
+        if b3_codec:
+            # replace the codec with a B3 enabled instance
+            return {Format.HTTP_HEADERS: B3Codec()}
+        return {}
+
     @staticmethod
     def initialized():
         with Config._initialized_lock:
@@ -308,6 +318,7 @@ class Config(object):
             debug_id_header=self.debug_id_header,
             tags=self.tags,
             max_tag_value_length=self.max_tag_value_length,
+            extra_codecs=self.extra_codecs,
         )
 
     def _initialize_global_tracer(self, tracer):

--- a/jaeger_client/constants.py
+++ b/jaeger_client/constants.py
@@ -68,3 +68,9 @@ SAMPLER_TYPE_LOWER_BOUND = 'lowerbound'
 
 # max length for tag values. Longer values will be truncated.
 MAX_TAG_VALUE_LENGTH = 1024
+
+# Constant for sampled flag
+SAMPLED_FLAG = 0x01
+
+# Constant for debug flag
+DEBUG_FLAG = 0x02

--- a/jaeger_client/span.py
+++ b/jaeger_client/span.py
@@ -22,9 +22,7 @@ import time
 import opentracing
 from opentracing.ext import tags as ext_tags
 from . import codecs, thrift
-
-SAMPLED_FLAG = 0x01
-DEBUG_FLAG = 0x02
+from .constants import SAMPLED_FLAG, DEBUG_FLAG
 
 
 class Span(opentracing.Span):

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -309,8 +309,8 @@ class TestCodecs(unittest.TestCase):
         span = Span(context=ctx, operation_name='x', tracer=None, start_time=1)
         carrier = {}
         codec.inject(span_context=span, carrier=carrier)
-        assert carrier == {'X-B3-SpanId': format(127, 'x'),
-                           'X-B3-TraceId': format(256, 'x'), 'X-B3-Flags': '1'}
+        assert carrier == {'X-B3-SpanId': format(127, 'x').zfill(16),
+                           'X-B3-TraceId': format(256, 'x').zfill(16), 'X-B3-Flags': '1'}
 
     def test_b3_codec_inject_parent(self):
         codec = B3Codec()
@@ -322,8 +322,8 @@ class TestCodecs(unittest.TestCase):
         span = Span(context=ctx, operation_name='x', tracer=None, start_time=1)
         carrier = {}
         codec.inject(span_context=span, carrier=carrier)
-        assert carrier == {'X-B3-SpanId': format(127, 'x'), 'X-B3-ParentSpanId': format(32, 'x'),
-                           'X-B3-TraceId': format(256, 'x'), 'X-B3-Flags': '1'}
+        assert carrier == {'X-B3-SpanId': format(127, 'x').zfill(16), 'X-B3-ParentSpanId': format(32, 'x').zfill(16),
+                           'X-B3-TraceId': format(256, 'x').zfill(16), 'X-B3-Flags': '1'}
 
     def test_b3_extract(self):
         codec = B3Codec()
@@ -348,14 +348,6 @@ class TestCodecs(unittest.TestCase):
         # validate invalid hex string
         with self.assertRaises(SpanContextCorruptedException):
             codec.extract({'x-b3-traceid': 'a2fb4a1d1a96d312z'})
-
-        # validate invalid length span
-        with self.assertRaises(SpanContextCorruptedException):
-            codec.extract({'x-b3-traceid': 'a2fb4a1d1a96d312', 'x-b3-spanid': 'beef'})
-
-        # validate invalid length trace
-        with self.assertRaises(SpanContextCorruptedException):
-            codec.extract({'x-b3-traceid': 'a2fb4a1d1a96d3123'})
 
         # validate non-string header
         with self.assertRaises(SpanContextCorruptedException):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -94,9 +94,9 @@ class ConfigTests(unittest.TestCase):
         t = c.create_tracer(NullReporter(), ConstSampler(True))
         assert t.max_tag_value_length == 333
 
-    def test_b3_codec(self):
+    def test_propagation(self):
         c = Config({}, service_name='x')
-        assert c.extra_codecs == {}
+        assert c.propagation == {}
 
-        c = Config({'b3_codec': True}, service_name='x')
-        assert c.extra_codecs
+        c = Config({'propagation': 'b3'}, service_name='x')
+        assert len(c.propagation) == 1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -93,3 +93,10 @@ class ConfigTests(unittest.TestCase):
 
         t = c.create_tracer(NullReporter(), ConstSampler(True))
         assert t.max_tag_value_length == 333
+
+    def test_b3_codec(self):
+        c = Config({}, service_name='x')
+        assert c.extra_codecs == {}
+
+        c = Config({'b3_codec': True}, service_name='x')
+        assert c.extra_codecs


### PR DESCRIPTION
A new config parameter called `b3_codec` is available to use the B3 codec with HTTP headers

Fixes #106 

Signed-off-by: Gabriel Gravel <ggravel@appnexus.com>