### PR TITLE
python3 compat, hasattr iteritems->items

### DIFF
--- a/jaeger_client/codecs.py
+++ b/jaeger_client/codecs.py
@@ -82,7 +82,7 @@ class TextCodec(Codec):
                 carrier[header_key] = encoded_value
 
     def extract(self, carrier):
-        if not hasattr(carrier, 'iteritems'):
+        if not hasattr(carrier, 'items'):
             raise InvalidCarrierException('carrier not a collection')
         trace_id, span_id, parent_id, flags = None, None, None, None
         baggage = None


### PR DESCRIPTION
I'm not sure what data structures this test was for, but for python3 it fails because dict has no iteritems.  Changes were made around it for six.iteritems, but this change was missed.

Once i made this change (and another PR to django_opentracing), i was able to run django_opentracing on django python3