### PR TITLE
Fix dependencies for Py3 compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,9 @@ PY_PATH = $(PYTHONPATH):$(PWD)
 bootstrap:
 	[ "$$VIRTUAL_ENV" != "" ]
 	rm -rf *.egg-info || true
-	pip install -U 'pip>=7.0,<8.0'
+	if [ "$(python --version 2>&1)" =~ 'Python 2' ] ;  pip install -U 'pip>=7.0,<8.0'; fi
+	if [ "$(python --version 2>&1)" =~ 'Python 3' ] ;  pip install -U 'pip>=9.0'; fi
+	pip install 'setuptools>=20.8.1'
 	pip install -r requirements.txt
 	pip install -r requirements-dev.txt
 	pip install -r requirements-tests.txt

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,7 @@ PY_PATH = $(PYTHONPATH):$(PWD)
 bootstrap:
 	[ "$$VIRTUAL_ENV" != "" ]
 	rm -rf *.egg-info || true
-	if [ "$(python --version 2>&1)" =~ 'Python 2' ] ;  pip install -U 'pip>=7.0,<8.0'; fi
-	if [ "$(python --version 2>&1)" =~ 'Python 3' ] ;  pip install -U 'pip>=9.0'; fi
+	pip install -U 'pip>=9.0'
 	pip install 'setuptools>=20.8.1'
 	pip install -r requirements.txt
 	pip install -r requirements-dev.txt

--- a/jaeger_client/codecs.py
+++ b/jaeger_client/codecs.py
@@ -74,7 +74,7 @@ class TextCodec(Codec):
                     # into HTTP headers. httplib does not like unicode strings
                     # so we convert the key to utf-8. The URL-encoded value is
                     # already a plain string.
-                    if isinstance(key, unicode):
+                    if six.PY2 and isinstance(key, six.text_type):
                         encoded_key = key.encode('utf-8')
                 else:
                     encoded_value = value
@@ -236,7 +236,7 @@ class ZipkinCodec(Codec):
 
 
 def header_to_hex(header):
-    if not isinstance(header, (str, unicode)):
+    if not isinstance(header, (str, six.text_type)):
         raise SpanContextCorruptedException(
             'malformed trace context "%s", expected hex string' % header)
 

--- a/setup.py
+++ b/setup.py
@@ -35,13 +35,13 @@ setup(
         'Programming Language :: Python :: 2.7',
     ],
     install_requires=[
-        'futures',
+        'futures;python_version<"3"',
         'threadloop>=1,<2',
         # we want thrift>=0.9.2.post1,<0.9.3, but we let the users pin to that
         'thrift',
         'tornado>=4.3,<5',
-        'opentracing>=1.2.2,<1.3',
-        "future",
+        'opentracing>=1.2.2,<1.4',
+        'future',
     ],
     # Uncomment below if need to test with unreleased version of opentracing
     # dependency_links=[
@@ -61,7 +61,7 @@ setup(
             'flake8<3',  # see https://github.com/zheller/flake8-quotes/issues/29
             'flake8-quotes',
             'coveralls',
-            'tchannel>=0.27',
+            'tchannel>=0.27;python_version<"3"',
             'opentracing_instrumentation>=2,<3',
         ]
     },


### PR DESCRIPTION
* Bump opentracing so that it does not import `futures`
* Exclude `tchannel` because it also imports `futures`. We can restrict crossdock to only run in py2.
* Minor fixes to codecs and codecs tests to let them compile in Py3 (but they still fail)


Signed-off-by: Yuri Shkuro <ys@uber.com>