### PR TITLE
Resolve tag unicode issues

### DIFF
--- a/jaeger_client/span.py
+++ b/jaeger_client/span.py
@@ -86,15 +86,12 @@ class Span(opentracing.Span):
                     self.context.flags &= ~SAMPLED_FLAG
             elif self.is_sampled():
 
-                if isinstance(value, basestring):
-                    try:
-                        value = value.decode('latin1')
-                    except UnicodeEncodeError:
-                        pass
+                if not isinstance(value, basestring):
+                    value = str(value)
 
                 tag = thrift.make_string_tag(
                     key=key,
-                    value=str(value),
+                    value=value,
                     max_length=self.tracer.max_tag_value_length,
                 )
                 self.tags.append(tag)

--- a/jaeger_client/span.py
+++ b/jaeger_client/span.py
@@ -85,6 +85,13 @@ class Span(opentracing.Span):
                 else:
                     self.context.flags &= ~SAMPLED_FLAG
             elif self.is_sampled():
+
+                if isinstance(value, basestring):
+                    try:
+                        value = value.decode('latin1')
+                    except UnicodeEncodeError:
+                        pass
+
                 tag = thrift.make_string_tag(
                     key=key,
                     value=str(value),

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -224,3 +224,12 @@ def test_span_tag_value_max_length(tracer):
     tag_n = len(span.tags) - 1
     assert span.tags[tag_n].key == 'x'
     assert span.tags[tag_n].vStr == 'x' * 42
+
+
+def test_span_tag_value_unicode(tracer):
+    span = tracer.start_span(operation_name='x')
+    latin1_encoded_string = u'caf\xe9'.encode('latin1')
+    span.set_tag('x', latin1_encoded_string)
+    tag_n = len(span.tags) - 1
+    assert span.tags[tag_n].key == 'x'
+    assert span.tags[tag_n].vStr == 'x' * 42

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -226,10 +226,18 @@ def test_span_tag_value_max_length(tracer):
     assert span.tags[tag_n].vStr == 'x' * 42
 
 
-def test_span_tag_value_unicode(tracer):
+def test_span_tag_value_unicode_latin1(tracer):
     span = tracer.start_span(operation_name='x')
     latin1_encoded_string = u'caf\xe9'.encode('latin1')
     span.set_tag('x', latin1_encoded_string)
     tag_n = len(span.tags) - 1
     assert span.tags[tag_n].key == 'x'
-    assert span.tags[tag_n].vStr == 'x' * 42
+    assert span.tags[tag_n].vStr == u'caf\xe9'
+
+
+def test_span_tag_value_actual_unicode(tracer):
+    span = tracer.start_span(operation_name='x')
+    span.set_tag('x', u'caf\xe9')
+    tag_n = len(span.tags) - 1
+    assert span.tags[tag_n].key == 'x'
+    assert span.tags[tag_n].vStr == u'caf\xe9'

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -232,7 +232,7 @@ def test_span_tag_value_unicode_latin1(tracer):
     span.set_tag('x', latin1_encoded_string)
     tag_n = len(span.tags) - 1
     assert span.tags[tag_n].key == 'x'
-    assert span.tags[tag_n].vStr == u'caf\xe9'
+    assert span.tags[tag_n].vStr == 'caf\xe9'
 
 
 def test_span_tag_value_actual_unicode(tracer):


### PR DESCRIPTION
Context:
Getting errors when running [`before_request`](https://github.com/uber-common/opentracing-python-instrumentation/blob/master/opentracing_instrumentation/http_server.py#L35) on a tornado request that has unicode characters in the URL. 

From digging into tornado source, it looks like here they convert the url to `latin1`:
https://github.com/tornadoweb/tornado/blob/023a9ac87aa2de87585b71b8fee213346f4b590c/tornado/wsgi.py#L193-L194

https://github.com/tornadoweb/tornado/blob/023a9ac87aa2de87585b71b8fee213346f4b590c/tornado/wsgi.py#L55-L62

So the `http.url` being set as a tag in the opentracing instrumentation is actually a `latin1` encoding of those unicode characters. Then, when we try and cast it to the future `str`, It tries to decode again it appears, resulting in:
`UnicodeDecodeError: 'ascii' codec can't decode byte 0xe9 in position 3: ordinal not in range(128)`

I have recreated essentially what tornado is doing in the test cases here and put together a really quick solution. We would almost certainly want to factor this string handling out of `set_tag` but I will let someone more familiar with this codebase give me guidance on where that should go.
