### PR TITLE
Encode even url-encoded string to utf-8

### DIFF
--- a/jaeger_client/codecs.py
+++ b/jaeger_client/codecs.py
@@ -72,10 +72,10 @@ class TextCodec(Codec):
                     encoded_value = urllib.parse.quote(value)
                     # we assume that self.url_encoding means we are injecting
                     # into HTTP headers. httplib does not like unicode strings
-                    # so we convert the key to utf-8. The URL-encoded value is
-                    # already a plain string.
+                    # so we convert the key to utf-8.
                     if six.PY2 and isinstance(key, six.text_type):
                         encoded_key = key.encode('utf-8')
+                        encoded_value = encoded_value.encode('utf-8')
                 else:
                     encoded_value = value
                 header_key = '%s%s' % (self.baggage_prefix, encoded_key)


### PR DESCRIPTION
It turns out that even though `urllib.parse.quote()` returns a value that prints without the `u` prefix, it is still considered unicode by `isinstance(s2, unicode)`

```
>>> from future import standard_library
>>> standard_library.install_aliases()  # noqa
>>> import six
>>> import urllib.parse
>>> s = 'ø'.decode('utf-8')
>>> s
u'\xf8'
>>> isinstance(s, str), isinstance(s, unicode)
(False, True)
>>> s2 = urllib.parse.quote(s)
>>> s2
'%C3%B8'
>>> isinstance(s2, str), isinstance(s2, unicode)
(False, True)
>>> s3 = 'hello %s' % (s2,)
>>> s3
u'hello %C3%B8'
>>> isinstance(s3, str), isinstance(s3, unicode)
(False, True)
>>> s4 = s2.encode('utf-8')
>>> s4
b'%C3%B8'
>>> isinstance(s4, str), isinstance(s4, unicode)
(True, False)
```

Here `s2` prints without `u` prefix, but still compares as unicode. And when concatenated with another plain string the result is real unicode `u'hello %C3%B8'`. However, `s4 = s2.encode('utf-8')` results in a byte string.

Signed-off-by: Yuri Shkuro <ys@uber.com>