### PR TITLE
Make Metrics consistent with Go client.

### DIFF
--- a/jaeger_client/reporter.py
+++ b/jaeger_client/reporter.py
@@ -233,13 +233,14 @@ class Reporter(NullReporter):
 class ReporterMetrics(object):
     def __init__(self, metrics_factory):
         self.reporter_success = \
-            metrics_factory.create_counter(name='jaeger.reporter_spans', tags={'result': 'ok'})
+            metrics_factory.create_counter(name='jaeger:reporter_spans', tags={'result': 'ok'})
         self.reporter_failure = \
-            metrics_factory.create_counter(name='jaeger.reporter_spans', tags={'result': 'err'})
+            metrics_factory.create_counter(name='jaeger:reporter_spans', tags={'result': 'err'})
         self.reporter_dropped = \
-            metrics_factory.create_counter(name='jaeger.reporter_spans', tags={'result': 'dropped'})
+            metrics_factory.create_counter(name='jaeger:reporter_spans', tags={'result': 'dropped'})
         self.reporter_socket = \
-            metrics_factory.create_counter(name='jaeger.reporter_spans', tags={'result': 'socket_error'})
+            metrics_factory.create_counter(name='jaeger:reporter_spans',
+                                           tags={'result': 'socket_error'})
 
 
 class CompositeReporter(NullReporter):

--- a/jaeger_client/reporter.py
+++ b/jaeger_client/reporter.py
@@ -233,13 +233,13 @@ class Reporter(NullReporter):
 class ReporterMetrics(object):
     def __init__(self, metrics_factory):
         self.reporter_success = \
-            metrics_factory.create_counter(name='jaeger.spans', tags={'reported': 'true'})
+            metrics_factory.create_counter(name='jaeger.reporter_spans', tags={'result': 'ok'})
         self.reporter_failure = \
-            metrics_factory.create_counter(name='jaeger.spans', tags={'reported': 'false'})
+            metrics_factory.create_counter(name='jaeger.reporter_spans', tags={'result': 'err'})
         self.reporter_dropped = \
-            metrics_factory.create_counter(name='jaeger.spans', tags={'dropped': 'true'})
+            metrics_factory.create_counter(name='jaeger.reporter_spans', tags={'result': 'dropped'})
         self.reporter_socket = \
-            metrics_factory.create_counter(name='jaeger.spans', tags={'socket_error': 'true'})
+            metrics_factory.create_counter(name='jaeger.reporter_spans', tags={'result': 'socket_error'})
 
 
 class CompositeReporter(NullReporter):

--- a/jaeger_client/reporter.py
+++ b/jaeger_client/reporter.py
@@ -171,6 +171,7 @@ class Reporter(NullReporter):
                         spans.append(span)
             if spans:
                 yield self._submit(spans)
+                self.metrics.reporter_queue_length(self.queue.qsize())
                 for _ in spans:
                     self.queue.task_done()
                 spans = spans[:0]
@@ -243,6 +244,8 @@ class ReporterMetrics(object):
         self.reporter_socket = \
             metrics_factory.create_counter(name='jaeger:reporter_spans',
                                            tags={'result': 'socket_error'})
+        self.reporter_queue_length = \
+            metrics_factory.create_gauge(name="jaeger:reporter_queue_length")
 
 
 class CompositeReporter(NullReporter):

--- a/jaeger_client/reporter.py
+++ b/jaeger_client/reporter.py
@@ -231,6 +231,8 @@ class Reporter(NullReporter):
 
 
 class ReporterMetrics(object):
+    """Reporter specific metrics."""
+
     def __init__(self, metrics_factory):
         self.reporter_success = \
             metrics_factory.create_counter(name='jaeger:reporter_spans', tags={'result': 'ok'})

--- a/jaeger_client/sampler.py
+++ b/jaeger_client/sampler.py
@@ -443,9 +443,9 @@ class RemoteControlledSampler(Sampler):
     def _update_adaptive_sampler(self, per_operation_strategies):
         if isinstance(self.sampler, AdaptiveSampler):
             self.sampler.update(per_operation_strategies)
-            self.metrics.sampler_updated(1)
         else:
             self.sampler = AdaptiveSampler(per_operation_strategies, self.max_operations)
+        self.metrics.sampler_updated(1)
 
     def _update_rate_limiting_or_probabilistic_sampler(self, response):
         s_type = response.get(STRATEGY_TYPE_STR)

--- a/jaeger_client/sampler.py
+++ b/jaeger_client/sampler.py
@@ -498,7 +498,7 @@ def get_rate_limit(strategy=None):
 
 
 class SamplerMetrics(object):
-    """Tracer specific metrics."""
+    """Sampler specific metrics."""
 
     def __init__(self, metrics_factory):
         self.sampler_retrieved = \

--- a/jaeger_client/sampler.py
+++ b/jaeger_client/sampler.py
@@ -344,7 +344,7 @@ class RemoteControlledSampler(Sampler):
         self.metrics_factory = kwargs.get('metrics_factory', None) \
             or LegacyMetricsFactory(kwargs.get('metrics', None) or Metrics())
         self.sampler_errors = \
-            self.metrics_factory.create_counter('jaeger.sampler', {'error': 'true'})
+            self.metrics_factory.create_counter(name='jaeger.sampler', tags={'result': 'err'})
         self.error_reporter = kwargs.get('error_reporter') or \
             ErrorReporter(Metrics())
         self.max_operations = kwargs.get('max_operations', DEFAULT_MAX_OPERATIONS)

--- a/jaeger_client/sampler.py
+++ b/jaeger_client/sampler.py
@@ -343,8 +343,7 @@ class RemoteControlledSampler(Sampler):
             kwargs.get('sampling_refresh_interval', DEFAULT_SAMPLING_INTERVAL)
         self.metrics_factory = kwargs.get('metrics_factory', None) \
             or LegacyMetricsFactory(kwargs.get('metrics', None) or Metrics())
-        self.sampler_errors = \
-            self.metrics_factory.create_counter(name='jaeger.sampler', tags={'result': 'err'})
+        self.metrics = SamplerMetrics(self.metrics_factory)
         self.error_reporter = kwargs.get('error_reporter') or \
             ErrorReporter(Metrics())
         self.max_operations = kwargs.get('max_operations', DEFAULT_MAX_OPERATIONS)
@@ -408,7 +407,7 @@ class RemoteControlledSampler(Sampler):
     def _sampling_request_callback(self, future):
         exception = future.exception()
         if exception:
-            self.sampler_errors(1)
+            self.metrics.sampler_query_failure(1)
             self.error_reporter.error(
                 'Fail to get sampling strategy from jaeger-agent: %s',
                 exception)
@@ -417,8 +416,9 @@ class RemoteControlledSampler(Sampler):
         response = future.result()
         try:
             sampling_strategies_response = json.loads(response.body)
+            self.metrics.sampler_retrieved(1)
         except Exception as e:
-            self.sampler_errors(1)
+            self.metrics.sampler_query_failure(1)
             self.error_reporter.error(
                 'Fail to parse sampling strategy '
                 'from jaeger-agent: %s [%s]', e, response.body)
@@ -435,7 +435,7 @@ class RemoteControlledSampler(Sampler):
                 else:
                     self._update_rate_limiting_or_probabilistic_sampler(response)
             except Exception as e:
-                self.sampler_errors(1)
+                self.metrics.sampler_update_failure(1)
                 self.error_reporter.error(
                     'Fail to update sampler'
                     'from jaeger-agent: %s [%s]', e, response)
@@ -443,6 +443,7 @@ class RemoteControlledSampler(Sampler):
     def _update_adaptive_sampler(self, per_operation_strategies):
         if isinstance(self.sampler, AdaptiveSampler):
             self.sampler.update(per_operation_strategies)
+            self.metrics.sampler_updated(1)
         else:
             self.sampler = AdaptiveSampler(per_operation_strategies, self.max_operations)
 
@@ -463,6 +464,7 @@ class RemoteControlledSampler(Sampler):
 
         if self.sampler != new_sampler:
             self.sampler = new_sampler
+            self.metrics.sampler_updated(1)
 
     def _poll_sampling_manager(self):
         self.logger.debug('Requesting tracing sampler refresh')
@@ -493,3 +495,17 @@ def get_rate_limit(strategy=None):
     if not rate_limit_strategy:
         return DEFAULT_LOWER_BOUND
     return rate_limit_strategy.get(MAX_TRACES_PER_SECOND_STR, DEFAULT_LOWER_BOUND)
+
+
+class SamplerMetrics(object):
+    """Tracer specific metrics."""
+
+    def __init__(self, metrics_factory):
+        self.sampler_retrieved = \
+            metrics_factory.create_counter(name='jaeger:sampler_queries', tags={'result': 'ok'})
+        self.sampler_query_failure = \
+            metrics_factory.create_counter(name='jaeger:sampler_queries', tags={'result': 'err'})
+        self.sampler_updated = \
+            metrics_factory.create_counter(name='jaeger:sampler_updates', tags={'result': 'ok'})
+        self.sampler_update_failure = \
+            metrics_factory.create_counter(name='jaeger:sampler_updates', tags={'result': 'err'})

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -206,9 +206,9 @@ class Tracer(opentracing.Tracer):
 
     def _emit_span_metrics(self, span, join=False):
         if span.is_sampled():
-            self.metrics.spans_sampled(1)
+            self.metrics.spans_started_sampled(1)
         else:
-            self.metrics.spans_not_sampled(1)
+            self.metrics.spans_started_not_sampled(1)
         if not span.context.parent_id:
             if span.is_sampled():
                 if join:
@@ -224,6 +224,7 @@ class Tracer(opentracing.Tracer):
 
     def report_span(self, span):
         self.reporter.report_span(span)
+        self.metrics.spans_finished(1)
 
     def random_id(self):
         return self.random.getrandbits(constants.MAX_ID_BITS)
@@ -234,14 +235,20 @@ class TracerMetrics(object):
 
     def __init__(self, metrics_factory):
         self.traces_started_sampled = \
-            metrics_factory.create_counter(name='jaeger.traces', tags={'state': 'started', 'sampled': 'y'})
+            metrics_factory.create_counter(name='jaeger:traces',
+                                           tags={'state': 'started', 'sampled': 'y'})
         self.traces_started_not_sampled = \
-            metrics_factory.create_counter(name='jaeger.traces', tags={'state': 'started', 'sampled': 'n'})
+            metrics_factory.create_counter(name='jaeger:traces',
+                                           tags={'state': 'started', 'sampled': 'n'})
         self.traces_joined_sampled = \
-            metrics_factory.create_counter(name='jaeger.traces', tags={'state': 'joined', 'sampled': 'y'})
+            metrics_factory.create_counter(name='jaeger:traces',
+                                           tags={'state': 'joined', 'sampled': 'y'})
         self.traces_joined_not_sampled = \
-            metrics_factory.create_counter(name='jaeger.traces', tags={'state': 'joined', 'sampled': 'n'})
-        self.spans_sampled = \
-            metrics_factory.create_counter(name='jaeger.started_spans', tags={'sampled': 'y'})
-        self.spans_not_sampled = \
-            metrics_factory.create_counter(name='jaeger.started_spans', tags={'sampled': 'n'})
+            metrics_factory.create_counter(name='jaeger:traces',
+                                           tags={'state': 'joined', 'sampled': 'n'})
+        self.spans_started_sampled = \
+            metrics_factory.create_counter(name='jaeger:started_spans', tags={'sampled': 'y'})
+        self.spans_started_not_sampled = \
+            metrics_factory.create_counter(name='jaeger:started_spans', tags={'sampled': 'n'})
+        self.spans_finished = \
+            metrics_factory.create_counter(name='jaeger:finished_spans')

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -234,14 +234,14 @@ class TracerMetrics(object):
 
     def __init__(self, metrics_factory):
         self.traces_started_sampled = \
-            metrics_factory.create_counter(name='jaeger.traces-started', tags={'sampled': 'true'})
+            metrics_factory.create_counter(name='jaeger.traces', tags={'state': 'started', 'sampled': 'y'})
         self.traces_started_not_sampled = \
-            metrics_factory.create_counter(name='jaeger.traces-started', tags={'sampled': 'false'})
+            metrics_factory.create_counter(name='jaeger.traces', tags={'state': 'started', 'sampled': 'n'})
         self.traces_joined_sampled = \
-            metrics_factory.create_counter(name='jaeger.traces-joined', tags={'sampled': 'true'})
+            metrics_factory.create_counter(name='jaeger.traces', tags={'state': 'joined', 'sampled': 'y'})
         self.traces_joined_not_sampled = \
-            metrics_factory.create_counter(name='jaeger.traces-joined', tags={'sampled': 'false'})
+            metrics_factory.create_counter(name='jaeger.traces', tags={'state': 'joined', 'sampled': 'n'})
         self.spans_sampled = \
-            metrics_factory.create_counter(name='jaeger.spans', tags={'sampled': 'true'})
+            metrics_factory.create_counter(name='jaeger.started_spans', tags={'sampled': 'y'})
         self.spans_not_sampled = \
-            metrics_factory.create_counter(name='jaeger.spans', tags={'sampled': 'false'})
+            metrics_factory.create_counter(name='jaeger.started_spans', tags={'sampled': 'n'})

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -184,7 +184,7 @@ class ReporterTest(AsyncTestCase):
         assert 1 == len(sender.futures)
 
         # send after close
-        span_dropped_key = 'jaeger.reporter_spans.result_dropped'
+        span_dropped_key = 'jaeger:reporter_spans.result_dropped'
         assert span_dropped_key not in reporter.metrics_factory.counters
         reporter.report_span(self._new_span('1'))
         assert 1 == reporter.metrics_factory.counters[span_dropped_key]
@@ -195,7 +195,7 @@ class ReporterTest(AsyncTestCase):
         reporter.error_reporter = ErrorReporter(
             metrics=Metrics(), logger=logging.getLogger())
 
-        reporter_failure_key = 'jaeger.reporter_spans.result_err'
+        reporter_failure_key = 'jaeger:reporter_spans.result_err'
         assert reporter_failure_key not in reporter.metrics_factory.counters
 
         # simulate exception in send
@@ -218,7 +218,7 @@ class ReporterTest(AsyncTestCase):
         assert 1 == len(sender.futures)
         # the consumer is blocked on a future, so won't drain the queue
         reporter.report_span(self._new_span('2'))
-        span_dropped_key = 'jaeger.reporter_spans.result_dropped'
+        span_dropped_key = 'jaeger:reporter_spans.result_dropped'
         assert span_dropped_key not in reporter.metrics_factory.counters
         reporter.report_span(self._new_span('3'))
         yield self._wait_for(

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -184,7 +184,7 @@ class ReporterTest(AsyncTestCase):
         assert 1 == len(sender.futures)
 
         # send after close
-        span_dropped_key = 'jaeger.spans.dropped_true'
+        span_dropped_key = 'jaeger.reporter_spans.result_dropped'
         assert span_dropped_key not in reporter.metrics_factory.counters
         reporter.report_span(self._new_span('1'))
         assert 1 == reporter.metrics_factory.counters[span_dropped_key]
@@ -195,7 +195,7 @@ class ReporterTest(AsyncTestCase):
         reporter.error_reporter = ErrorReporter(
             metrics=Metrics(), logger=logging.getLogger())
 
-        reporter_failure_key = 'jaeger.spans.reported_false'
+        reporter_failure_key = 'jaeger.reporter_spans.result_err'
         assert reporter_failure_key not in reporter.metrics_factory.counters
 
         # simulate exception in send
@@ -218,7 +218,7 @@ class ReporterTest(AsyncTestCase):
         assert 1 == len(sender.futures)
         # the consumer is blocked on a future, so won't drain the queue
         reporter.report_span(self._new_span('2'))
-        span_dropped_key = 'jaeger.spans.dropped_true'
+        span_dropped_key = 'jaeger.reporter_spans.result_dropped'
         assert span_dropped_key not in reporter.metrics_factory.counters
         reporter.report_span(self._new_span('3'))
         yield self._wait_for(


### PR DESCRIPTION
Make Metrics consistent with Go client.

Now the metric name shows consistent with go-client as you see below prometheus test I did.
- in sampler, add SamplerMetrics which has 4 types of metrics, as go-client has.
- in tracer, add spans_finished 

Resolves #102 

Please review.

```
# HELP jaeger:traces jaeger:traces
# TYPE jaeger:traces counter
jaeger:traces{sampled="n",state="started"} 6.0
jaeger:traces{sampled="y",state="started"} 0.0
jaeger:traces{sampled="y",state="joined"} 0.0
jaeger:traces{sampled="n",state="joined"} 0.0
# HELP jaeger:sampler_updates jaeger:sampler_updates
# TYPE jaeger:sampler_updates counter
jaeger:sampler_updates{result="err"} 0.0
jaeger:sampler_updates{result="ok"} 0.0
# HELP python_info Python platform information
# TYPE python_info gauge
python_info{implementation="CPython",major="2",minor="7",patchlevel="10",version="2.7.10"} 1.0
# HELP jaeger:sampler_queries jaeger:sampler_queries
# TYPE jaeger:sampler_queries counter
jaeger:sampler_queries{result="err"} 0.0
jaeger:sampler_queries{result="ok"} 0.0
# HELP jaeger:started_spans jaeger:started_spans
# TYPE jaeger:started_spans counter
jaeger:started_spans{sampled="n"} 12.0
jaeger:started_spans{sampled="y"} 0.0
# HELP jaeger:finished_spans jaeger:finished_spans
# TYPE jaeger:finished_spans counter
jaeger:finished_spans 0.0
# HELP jaeger:reporter_spans jaeger:reporter_spans
# TYPE jaeger:reporter_spans counter
jaeger:reporter_spans{result="dropped"} 0.0
jaeger:reporter_spans{result="socket_error"} 0.0
jaeger:reporter_spans{result="err"} 0.0
jaeger:reporter_spans{result="ok"} 0.0
```

Signed-off-by: eundoo-song <eundoo.song@gmail.com>