### PR TITLE
Use only `six` for py2/py3 compatibility, drop `future`

### DIFF
--- a/jaeger_client/codecs.py
+++ b/jaeger_client/codecs.py
@@ -14,9 +14,6 @@
 
 from __future__ import absolute_import
 
-# from future import standard_library
-# standard_library.install_aliases()  # noqa
-
 from builtins import object
 from past.builtins import basestring
 

--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,10 @@ setup(
     extras_require={
         'tests': [
             'mock==1.0.1',
+            'pycurl>=7.43,<8',
             'pytest>=2.7,<3',
             'pytest-cov',
-            'coverage<4.4', # can remove after https://bitbucket.org/ned/coveragepy/issues/581/44b1-44-breaking-in-ci
+            'coverage<4.4',  # can remove after https://bitbucket.org/ned/coveragepy/issues/581/44b1-44-breaking-in-ci
             'pytest-timeout',
             'pytest-tornado',
             'pytest-benchmark[histogram]>=3.0.0rc1',

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
         'thrift',
         'tornado>=4.3,<5',
         'opentracing>=1.2.2,<1.4',
-        'future',
     ],
     # Uncomment below if need to test with unreleased version of opentracing
     # dependency_links=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@
 import mock
 import pytest
 from jaeger_client import ConstSampler, Tracer
+from tornado.httpclient import AsyncHTTPClient
 
 
 @pytest.fixture(scope='function')
@@ -23,3 +24,6 @@ def tracer():
     sampler = ConstSampler(True)
     return Tracer(
         service_name='test_service_1', reporter=reporter, sampler=sampler)
+
+AsyncHTTPClient.configure('tornado.curl_httpclient.CurlAsyncHTTPClient')
+print('Configured AsyncHTTPClient to use tornado.curl_httpclient.CurlAsyncHTTPClient')

--- a/tests/test_local_agent_net.py
+++ b/tests/test_local_agent_net.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 import pytest
 import tornado.web
 from urllib.parse import urlparse
@@ -28,7 +26,7 @@ test_strategy = """
             "samplingRate":0.002
         }
     }
-    """
+"""
 
 
 class AgentHandler(tornado.web.RequestHandler):

--- a/tests/test_thrift.py
+++ b/tests/test_thrift.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future import standard_library
-standard_library.install_aliases()
 from io import BytesIO
 
 import jaeger_client.thrift_gen.jaeger.ttypes as ttypes


### PR DESCRIPTION
After installing `pycurl>=7.43,<8` and configuring tornado async client to use curl client in `testconf.py`:
```python
AsyncHTTPClient.configure('tornado.curl_httpclient.CurlAsyncHTTPClient')
```

some tests start failing with:
```
___________________ test_trace_propagation[HTTP-HTTP-True]
tests/test_crossdock.py:115: in test_trace_propagation
    assert tr.downstream.span.baggage == level1.get("baggage")
E   assert "b'Zoidberg'" == 'Zoidberg'
E     - b'Zoidberg'
E     ? --        -
E     + Zoidberg
```

Special thanks to @dray92 for narrowing it down.

The reason is because the `future` module implements `urllib.parse.quote` to return a `newstr` object that in turn returns `newbytes` object after encoding, and the latter gets serialized with the `b` prefix, causing the breaks above.

The fix is to stop using `future` module (it was only needed in one file) and instead use `six.moves.urllib.parse`, which fixes the tests.

Signed-off-by: Yuri Shkuro <ys@uber.com>