### PR TITLE
Create a simple tox file to test multiple python versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+envlist=py27,py36,pep8
+
+[testenv]
+commands=py.test tests/
+deps=pytest
+     -r{toxinidir}/requirements.txt
+     -r{toxinidir}/requirements-dev.txt
+     -r{toxinidir}/requirements-tests.txt
+install_command=pip install --find-links {toxinidir}/local {opts} {packages}
+
+[testenv:pep8]
+basepython=python
+deps=flake8
+commands=flake8 {toxinidir}/jaeger_client crossdock tests


### PR DESCRIPTION
This will make it easier to test both python 2.x and python 3.x
concurrently

Work will be done in follow up commits to move some bits of the Makefile
over to using tox