### PR TITLE
Remove LINUX specific installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Please see [CONTRIBUTING.md](./CONTRIBUTING.md).
 ## Installation
 
 ```bash
-apt-get install python-dev
 pip install jaeger-client
 ```
 


### PR DESCRIPTION
Signed-off-by: Prakriti <prakritibansal98@gmail.com>

- Remove python installation instruction specific to LINUX
- Fixes #139 