### PR TITLE
WIP Add sampling_finalized flag

### DIFF
--- a/jaeger_client/span_context.py
+++ b/jaeger_client/span_context.py
@@ -19,16 +19,32 @@ import opentracing
 
 class SpanContext(opentracing.SpanContext):
     __slots__ = ['trace_id', 'span_id', 'parent_id', 'flags',
-                 '_baggage', '_debug_id']
+                 '_baggage', '_debug_id', '_sampling_finalized']
 
     """Implements opentracing.SpanContext"""
-    def __init__(self, trace_id, span_id, parent_id, flags, baggage=None):
+    def __init__(self, trace_id, span_id, parent_id, flags, baggage=None, sampling_finalized=False):
         self.trace_id = trace_id
         self.span_id = span_id
         self.parent_id = parent_id or None
         self.flags = flags
         self._baggage = baggage or opentracing.SpanContext.EMPTY_BAGGAGE
         self._debug_id = None
+
+        # This field exists to help distinguish between when a span can have a properly
+        # correlated operation name -> sampling rate mapping, and when it cannot.
+        # Adaptive sampling uses the operation name of a span to correlate it with
+        # a sampling rate.  If an operation name is set on a span after the span's creation
+        # then adaptive sampling cannot associate the operation name with the proper sampling rate.
+        # In order to correct this we allow a span to be written to, so that we can re-sample
+        # it in the case that an operation name is set after span creation. Situations
+        # where a span context's sampling decision is finalized include:
+        #  - it has inherited the sampling decision from its parent
+        #  - its debug flag is set via the sampling.priority tag
+        #  - it is finish()-ed
+        #  - setOperationName is called
+        #  - it is used as a parent for another span
+        #  - its context is serialized using injectors
+        self._sampling_finalized = sampling_finalized
 
     @property
     def baggage(self):
@@ -43,6 +59,7 @@ class SpanContext(opentracing.SpanContext):
             parent_id=self.parent_id,
             flags=self.flags,
             baggage=baggage,
+            sampling_finalized=self.sampling_finalized
         )
 
     @property
@@ -60,3 +77,10 @@ class SpanContext(opentracing.SpanContext):
         )
         ctx._debug_id = debug_id
         return ctx
+
+    @property
+    def sampling_finalized(self):
+        return self._sampling_finalized
+
+    def finalize_sampling(self):
+        self._sampling_finalized = True

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -278,7 +278,6 @@ def test_adaptive_sampler_default_values():
     assert '%s' % adaptive_sampler.samplers['op'] == 'GuaranteedThroughputProbabilisticSampler(op, 0.001000, 0.001667)'
 
 
-
 def test_sampler_equality():
     const1 = ConstSampler(True)
     const2 = ConstSampler(True)

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -19,7 +19,7 @@ import json
 import mock
 
 from opentracing.ext import tags as ext_tags
-from jaeger_client import Span, SpanContext, ConstSampler
+from jaeger_client import Span, SpanContext, ConstSampler, Tracer, ProbabilisticSampler
 
 
 def test_baggage():
@@ -42,8 +42,8 @@ def test_baggage():
     assert span.get_baggage_item('x-Y') is None
 
 
-def _fields_to_dict(span_log):
-    return {f.key: f.vStr for f in span_log.fields}
+def _tags_to_dict(tags):
+    return {f.key: f.vStr for f in tags}
 
 
 def test_baggage_logs():
@@ -54,13 +54,13 @@ def test_baggage_logs():
     span.set_baggage_item('x', 'a')
     assert span.get_baggage_item('x') == 'a'
     assert len(span.logs) == 1
-    assert _fields_to_dict(span.logs[0]) == {
+    assert _tags_to_dict(span.logs[0].fields) == {
         "event": "baggage", "key": "x", "value": "a",
     }
     span.set_baggage_item('x', 'b')  # override
     assert span.get_baggage_item('x') == 'b'
     assert len(span.logs) == 2
-    assert _fields_to_dict(span.logs[1]) == {
+    assert _tags_to_dict(span.logs[1].fields) == {
         "event": "baggage", "key": "x", "value": "b", "override": "true",
     }
 
@@ -203,7 +203,7 @@ def test_span_logging(tracer):
 
         assert len(span.logs) == 1, name
         log = span.logs[0]
-        log_fields = _fields_to_dict(log)
+        log_fields = _tags_to_dict(log.fields)
         assert log_fields == test.expected
 
         if test.timestamp:
@@ -224,3 +224,82 @@ def test_span_tag_value_max_length(tracer):
     tag_n = len(span.tags) - 1
     assert span.tags[tag_n].key == 'x'
     assert span.tags[tag_n].vStr == 'x' * 42
+
+
+def test_sampling_finalized_on_setting_sampling_priority_tag(tracer):
+    span = tracer.start_span(operation_name='x')
+    assert not span.context.sampling_finalized
+
+    span.set_tag(ext_tags.SAMPLING_PRIORITY, 1)
+    assert span.context.sampling_finalized
+
+    unsampled_span = tracer.start_span(operation_name='unsampled_span')
+    unsampled_span.set_tag(ext_tags.SAMPLING_PRIORITY, 0)
+    assert unsampled_span.context.sampling_finalized
+
+
+def test_sampling_finalized_on_finished_span(tracer):
+    span = tracer.start_span(operation_name='x')
+    assert not span.context.sampling_finalized
+
+    span.finish()
+    assert span.context.sampling_finalized
+
+
+def test_sampling_finalized_on_set_operation_name(tracer):
+    span = tracer.start_span(operation_name='x')
+    assert not span.context.sampling_finalized
+
+    span.set_operation_name('y')
+    assert span.context.sampling_finalized
+
+
+def test_is_writeable_returns_true_if_no_finalized_or_the_span_is_sampled():
+    reporter = mock.MagicMock()
+    sampler = ConstSampler(False)
+    tracer = Tracer(
+        service_name='test_service_1', reporter=reporter, sampler=sampler)
+
+    unfinalized_span = tracer.start_span(operation_name='unfinalized_span')
+    assert not unfinalized_span.context.sampling_finalized
+    assert unfinalized_span._is_writeable()
+
+    unfinalized_span.finish()
+    assert not unfinalized_span._is_writeable()
+
+    tracer.sampler = ConstSampler(True)
+    sampled_span = tracer.start_span(operation_name='sampled_span')
+    assert sampled_span._is_writeable()
+
+
+def test_set_operation_name_should_add_sampler_tags_to_span_and_change_operation_name(tracer):
+    span = tracer.start_span(operation_name='x')
+    assert span.operation_name is 'x'
+    assert _tags_to_dict(span.tags) == {
+        "sampler.type": "const", "sampler.param": 'True'
+    }
+
+    tracer.sampler = ProbabilisticSampler(1.0)
+    span.set_operation_name(operation_name='y')
+    assert span.operation_name is 'y'
+    assert _tags_to_dict(span.tags) == {
+        "sampler.type": "probabilistic", "sampler.param": '1.0'
+    }
+
+
+def test_set_operation_name_should_not_change_sampler_tags_but_change_operation_name(tracer):
+    span = tracer.start_span(operation_name='x')
+    span.set_operation_name(operation_name='y')
+    assert span.operation_name is 'y'
+
+    # update sampler to something that will always sample
+    tracer.sampler = ProbabilisticSampler(1.0)
+
+    # The second call should rename the operation name, but
+    # not re-sample the span.  This is because finalize was set
+    # in the first 'setOperationName' call.
+    span.set_operation_name(operation_name='z')
+    assert span.operation_name is 'z'
+    assert _tags_to_dict(span.tags) == {
+        "sampler.type": "const", "sampler.param": 'True'
+    }

--- a/tests/test_span_context.py
+++ b/tests/test_span_context.py
@@ -24,7 +24,7 @@ def test_parent_id_to_none():
 def test_with_baggage_items():
     baggage1 = {'x': 'y'}
     ctx1 = SpanContext(trace_id=1, span_id=2, parent_id=3, flags=1,
-                       baggage=baggage1)
+                       baggage=baggage1, sampling_finalized=True)
     ctx2 = ctx1.with_baggage_item('a', 'b')
     assert ctx1.trace_id == ctx2.trace_id
     assert ctx1.span_id == ctx2.span_id
@@ -33,7 +33,7 @@ def test_with_baggage_items():
     assert ctx1.baggage != ctx2.baggage
     baggage1['a'] = 'b'
     assert ctx1.baggage == ctx2.baggage
-
+    assert ctx1.sampling_finalized == ctx2.sampling_finalized
 
 def test_is_debug_id_container_only():
     ctx = SpanContext.with_debug_id('value1')
@@ -41,3 +41,9 @@ def test_is_debug_id_container_only():
     assert ctx.debug_id == 'value1'
     ctx = SpanContext(trace_id=1, span_id=2, parent_id=3, flags=1)
     assert not ctx.is_debug_id_container_only
+
+def test_finalize_sampling():
+    ctx1 = SpanContext(trace_id=1, span_id=2, parent_id=0, flags=1)
+    assert not ctx1.sampling_finalized
+    ctx1.finalize_sampling()
+    assert ctx1.sampling_finalized


### PR DESCRIPTION
This field exists to help distinguish between when a span can have a properly correlated operation name -> sampling rate mapping, and when it cannot. Adaptive sampling uses the operation name of a span to correlate it with a sampling rate.  If an operation name is set on a span after the span's creation then adaptive sampling cannot associate the operation name with the proper sampling rate. In order to correct this we allow a span to be written to, so that we can re-sample it in the case that an operation name is set after span creation. Situations where a span context's sampling decision is finalized include:
- it has inherited the sampling decision from its parent
- its debug flag is set via the sampling.priority tag
- it is finish()-ed
- setOperationName is called
- it is used as a parent for another span
- its context is serialized using injectors/extractors


Signed-off-by: Won Jun Jang <wjang@uber.com>