### PR TITLE
Better support for creating multiple tracers

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ def init_jaeger_tracer(service_name='your-app-name'):
 ```
 
 Note that the call `initialize_tracer()` also sets the `opentracing.tracer` global variable.
+If you need to create additional tracers (e.g., to create spans on the client side for remote services that are not instrumented), use the `new_tracer()` method.
 
 #### Prometheus metrics
 

--- a/jaeger_client/config.py
+++ b/jaeger_client/config.py
@@ -296,6 +296,16 @@ class Config(object):
                 return
             Config._initialized = True
 
+        tracer = self.new_tracer(io_loop)
+
+        self._initialize_global_tracer(tracer=tracer)
+        return tracer
+
+    def new_tracer(self, io_loop=None):
+        """
+        Create a new Jaeger Tracer based on the passed `jaeger_client.Config`.
+        Does not set `opentracing.tracer` global variable.
+        """
         channel = self._create_local_agent_channel(io_loop=io_loop)
         sampler = self.sampler
         if sampler is None:
@@ -321,13 +331,10 @@ class Config(object):
         if self.logging:
             reporter = CompositeReporter(reporter, LoggingReporter(logger))
 
-        tracer = self.create_tracer(
+        return self.create_tracer(
             reporter=reporter,
             sampler=sampler,
         )
-
-        self._initialize_global_tracer(tracer=tracer)
-        return tracer
 
     def create_tracer(self, reporter, sampler):
         return Tracer(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import
 import os
 import unittest
+import opentracing.tracer
 from jaeger_client import Config, ConstSampler, ProbabilisticSampler, RateLimitingSampler
 from jaeger_client.reporter import NullReporter
 from jaeger_client import constants
@@ -104,3 +105,9 @@ class ConfigTests(unittest.TestCase):
     def test_for_unexpected_config_entries(self):
         with self.assertRaises(Exception):
             _ = Config({"unexpected":"value"}, validate=True)
+
+    def test_initialize_tracer(self):
+        c = Config({}, service_name='x')
+        tracer = c.initialize_tracer()
+
+        assert opentracing.tracer == tracer


### PR DESCRIPTION
Make it easier to create multiple tracers, for creating spans around calls to services that are not themselves instrumented (e.g. databases).

See https://github.com/jaegertracing/jaeger-client-python/issues/149