### PR TITLE
Remove tchannel;<py3 restriction in extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
             'flake8<3',  # see https://github.com/zheller/flake8-quotes/issues/29
             'flake8-quotes',
             'coveralls',
-            'tchannel>=0.27',
+            'tchannel>=0.27', # This is only used in python 2
             'opentracing_instrumentation>=2,<3',
             'prometheus_client',
         ]


### PR DESCRIPTION
To ensure backwards compatibility with older versions of setuptools

Signed-off-by: Won Jun Jang <wjang@uber.com>