### PR TITLE
Add IP tag to tracer tags

### DIFF
--- a/jaeger_client/constants.py
+++ b/jaeger_client/constants.py
@@ -47,6 +47,9 @@ JAEGER_VERSION_TAG_KEY = 'jaeger.version'
 # Tracer-scoped tag that contains the hostname
 JAEGER_HOSTNAME_TAG_KEY = 'jaeger.hostname'
 
+# Tracer-scoped tag that is used to report ip of the process.
+JAEGER_IP_TAG_KEY = 'ip'
+
 # the type of sampler that always makes the same decision.
 SAMPLER_TYPE_CONST = 'const'
 

--- a/jaeger_client/constants.py
+++ b/jaeger_client/constants.py
@@ -45,7 +45,7 @@ JAEGER_CLIENT_VERSION = 'Python-%s' % __version__
 JAEGER_VERSION_TAG_KEY = 'jaeger.version'
 
 # Tracer-scoped tag that contains the hostname
-JAEGER_HOSTNAME_TAG_KEY = 'jaeger.hostname'
+JAEGER_HOSTNAME_TAG_KEY = 'hostname'
 
 # Tracer-scoped tag that is used to report ip of the process.
 JAEGER_IP_TAG_KEY = 'ip'

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -80,6 +80,7 @@ class Tracer(opentracing.Tracer):
             self.codecs.update(extra_codecs)
         self.tags = {
             constants.JAEGER_VERSION_TAG_KEY: constants.JAEGER_CLIENT_VERSION,
+            constants.JAEGER_IP_TAG_KEY: self.ip_address,
         }
         if tags:
             self.tags.update(tags)

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -175,9 +175,9 @@ def test_tracer_tags():
 
     with mock.patch('socket.gethostname', return_value='dream-host.com'):
         t = Tracer(service_name='x', reporter=reporter, sampler=sampler)
-        assert t.tags.get(c.JAEGER_HOSTNAME_TAG_KEY) == 'dream-host.com'
-        assert c.JAEGER_IP_TAG_KEY in t.tags
-        assert c.JAEGER_VERSION_TAG_KEY in t.tags
+        assert t.tags.get('hostname') == 'dream-host.com'
+        assert 'ip' in t.tags
+        assert 'jaeger.version' in t.tags
 
 
 def test_tracer_tags_passed_to_reporter():

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -169,13 +169,15 @@ def test_serialization_error(tracer):
         )
 
 
-def test_tracer_tags_hostname():
+def test_tracer_tags():
     reporter = mock.MagicMock()
     sampler = ConstSampler(True)
 
     with mock.patch('socket.gethostname', return_value='dream-host.com'):
         t = Tracer(service_name='x', reporter=reporter, sampler=sampler)
         assert t.tags.get(c.JAEGER_HOSTNAME_TAG_KEY) == 'dream-host.com'
+        assert c.JAEGER_IP_TAG_KEY in t.tags
+        assert c.JAEGER_VERSION_TAG_KEY in t.tags
 
 
 def test_tracer_tags_passed_to_reporter():


### PR DESCRIPTION
Previously, the python client was using zipkin thrift to send spans to the agent. We changed this to use jaeger.thrift but lost the process IP tag in the process (<-pun). https://github.com/jaegertracing/jaeger-client-python/pull/111/files#diff-e57d8dbbca5079e5994623201c15401cL127 <- We added the IP to the zipkin endpoint object and it was converted to a process IP tag by the collector. Once we removed zipkin, we forgot to add back setting the IP tag.

Signed-off-by: Won Jun Jang <wjang@uber.com>