### PR TITLE
Allow specifying hostname and ip via tags

### DIFF
--- a/jaeger_client/thrift.py
+++ b/jaeger_client/thrift.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import six
-import socket
-import struct
 
 import jaeger_client.thrift_gen.jaeger.ttypes as ttypes
 import jaeger_client.thrift_gen.sampling.SamplingManager as sampling_manager
@@ -26,17 +24,6 @@ _max_unsigned_id = (1 << 64)
 
 if six.PY3:
     long = int
-
-
-def ipv4_to_int(ipv4):
-    if ipv4 == 'localhost':
-        ipv4 = '127.0.0.1'
-    elif ipv4 == '::1':
-        ipv4 = '127.0.0.1'
-    try:
-        return struct.unpack('!i', socket.inet_aton(ipv4))[0]
-    except:
-        return 0
 
 
 def id_to_int(big_id):

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -85,11 +85,13 @@ class Tracer(opentracing.Tracer):
         if tags:
             self.tags.update(tags)
         # noinspection PyBroadException
-        try:
-            hostname = socket.gethostname()
-            self.tags[constants.JAEGER_HOSTNAME_TAG_KEY] = hostname
-        except:
-            logger.exception('Unable to determine host name')
+
+        if self.tags.get(constants.JAEGER_HOSTNAME_TAG_KEY) is None:
+            try:
+                hostname = socket.gethostname()
+                self.tags[constants.JAEGER_HOSTNAME_TAG_KEY] = hostname
+            except:
+                logger.exception('Unable to determine host name')
 
         self.reporter.set_process(
             service_name=self.service_name,

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -29,7 +29,6 @@ from . import constants
 from .codecs import TextCodec, ZipkinCodec, ZipkinSpanFormat, BinaryCodec
 from .span import Span, SAMPLED_FLAG, DEBUG_FLAG
 from .span_context import SpanContext
-from .thrift import ipv4_to_int
 from .metrics import Metrics, LegacyMetricsFactory
 from .utils import local_ip
 
@@ -84,7 +83,7 @@ class Tracer(opentracing.Tracer):
             self.tags.update(tags)
 
         if self.tags.get(constants.JAEGER_IP_TAG_KEY) is None:
-            self.tags[constants.JAEGER_IP_TAG_KEY] = ipv4_to_int(local_ip())
+            self.tags[constants.JAEGER_IP_TAG_KEY] = local_ip()
 
         if self.tags.get(constants.JAEGER_HOSTNAME_TAG_KEY) is None:
             try:

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -84,13 +84,12 @@ class Tracer(opentracing.Tracer):
         }
         if tags:
             self.tags.update(tags)
-        # noinspection PyBroadException
 
         if self.tags.get(constants.JAEGER_HOSTNAME_TAG_KEY) is None:
             try:
                 hostname = socket.gethostname()
                 self.tags[constants.JAEGER_HOSTNAME_TAG_KEY] = hostname
-            except:
+            except socket.error:
                 logger.exception('Unable to determine host name')
 
         self.reporter.set_process(

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -53,7 +53,6 @@ class Tracer(opentracing.Tracer):
         self.service_name = service_name
         self.reporter = reporter
         self.sampler = sampler
-        self.ip_address = ipv4_to_int(local_ip())
         self.metrics_factory = metrics_factory or LegacyMetricsFactory(metrics or Metrics())
         self.metrics = TracerMetrics(self.metrics_factory)
         self.random = random.Random(time.time() * (os.getpid() or 1))
@@ -80,10 +79,12 @@ class Tracer(opentracing.Tracer):
             self.codecs.update(extra_codecs)
         self.tags = {
             constants.JAEGER_VERSION_TAG_KEY: constants.JAEGER_CLIENT_VERSION,
-            constants.JAEGER_IP_TAG_KEY: self.ip_address,
         }
         if tags:
             self.tags.update(tags)
+
+        if self.tags.get(constants.JAEGER_IP_TAG_KEY) is None:
+            self.tags[constants.JAEGER_IP_TAG_KEY] = ipv4_to_int(local_ip())
 
         if self.tags.get(constants.JAEGER_HOSTNAME_TAG_KEY) is None:
             try:

--- a/tests/test_thrift.py
+++ b/tests/test_thrift.py
@@ -24,13 +24,6 @@ from thrift.protocol.TCompactProtocol import TCompactProtocol
 from thrift.transport.TTransport import TMemoryBuffer
 
 
-def test_ipv4_to_int():
-    base = thrift.ipv4_to_int('127.0.0.1')
-    assert thrift.ipv4_to_int('localhost') == base
-    assert thrift.ipv4_to_int('::1') == base
-    assert thrift.ipv4_to_int('a:b:1') == 0
-
-
 def test_submit_batch(tracer):
     span = tracer.start_span("test-span")
     span.set_tag('bender', 'is great')

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -15,6 +15,7 @@
 import mock
 import random
 import six
+import socket
 
 import pytest
 import tornado.httputil
@@ -200,7 +201,7 @@ def test_tracer_tags_no_hostname():
     from jaeger_client.tracer import logger
     with mock.patch.object(logger, 'exception') as mock_log:
         with mock.patch('socket.gethostname',
-                        side_effect=['host', ValueError()]):
+                        side_effect=['host', socket.timeout()]):
             Tracer(service_name='x', reporter=reporter, sampler=sampler)
         assert mock_log.call_count == 1
 

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -262,6 +262,7 @@ def test_tracer_override_codecs():
         assert tracer.codecs[Format.BINARY] == "overridden_binary_codec",\
                 "Binary format codec not overridden"
 
+
 def test_tracer_hostname_tag():
     reporter = mock.MagicMock()
     sampler = ConstSampler(True)
@@ -274,3 +275,17 @@ def test_tracer_hostname_tag():
 
     assert tracer.tags[c.JAEGER_HOSTNAME_TAG_KEY] == \
             'jaeger-client-app.local'
+
+
+def test_tracer_ip_tag():
+    reporter = mock.MagicMock()
+    sampler = ConstSampler(True)
+    tracer = Tracer(
+        service_name='x',
+        tags={c.JAEGER_IP_TAG_KEY: '192.0.2.3'},
+        reporter=reporter,
+        sampler=sampler,
+    )
+
+    assert tracer.tags[c.JAEGER_IP_TAG_KEY] == \
+            '192.0.2.3'

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -260,3 +260,16 @@ def test_tracer_override_codecs():
                 "Extra codec not found"
         assert tracer.codecs[Format.BINARY] == "overridden_binary_codec",\
                 "Binary format codec not overridden"
+
+def test_tracer_hostname_tag():
+    reporter = mock.MagicMock()
+    sampler = ConstSampler(True)
+    tracer = Tracer(
+        service_name='x',
+        tags={c.JAEGER_HOSTNAME_TAG_KEY: 'jaeger-client-app.local'},
+        reporter=reporter,
+        sampler=sampler,
+    )
+
+    assert tracer.tags[c.JAEGER_HOSTNAME_TAG_KEY] == \
+            'jaeger-client-app.local'


### PR DESCRIPTION
This is much more useful in containerized environments such as kubernetes where the hostname and ip are generally useless autogenerated data. In kubernetes, the node name [can be injected](https://github.com/kubernetes/website/blob/8fd155a15f17181e65fafd051d485237ec0bd132/docs/tasks/inject-data-application/dapi-envars-pod.yaml#L18-L21) into the container as an env variable to be used.

I also cleaned up the bare except in the hostname lookup as [socket.error](https://docs.python.org/2/library/socket.html#socket.error) is the base exception for anything the module raises.

This change makes the python client match the java client from a logic perspective see:
jaegertracing/jaeger-client-java#371

Fixes #166 