### PR TITLE
Fixed a typo in reporter logs

### DIFF
--- a/jaeger_client/reporter.py
+++ b/jaeger_client/reporter.py
@@ -175,7 +175,7 @@ class Reporter(NullReporter):
                     self.queue.task_done()
                 spans = spans[:0]
             self.metrics.reporter_queue_length(self.queue.qsize())
-        self.logger.info('Span publisher exists')
+        self.logger.info('Span publisher exited')
 
     # method for protocol factory
     def getProtocol(self, transport):


### PR DESCRIPTION
There was a typo in this [line](https://github.com/jaegertracing/jaeger-client-python/blob/dee05477d551c326ee5b845fbef96606b9efe4cb/jaeger_client/reporter.py#L178).
Changed 'Span publisher exists' to 'Span publisher exited'

This was misleading. I was debugging missing spans and I thought that
my spans were missing because they already 'exist' somewhere and that
is the reason my spans aren't getting published. :D

Signed-off-by: Prasanna S <samthedevil.sp@gmail.com>