### PR TITLE
Reinstate dependency on futures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,14 +25,23 @@ bootstrap:
 	pip install -r requirements.txt
 	pip install -r requirements-dev.txt
 	pip install -r requirements-tests.txt
+	pip install virtualenv
 	python setup.py develop
+
 
 .PHONY: test
 test: clean
 	$(pytest) $(test_args) --benchmark-skip
 
 .PHONY: test_ci
-test_ci: clean test lint
+test_ci: clean test-import test lint
+
+.PHONY: test-import
+test-import:
+	virtualenv import-test
+	import-test/bin/pip install -e .
+	import-test/bin/python -c "import jaeger_client"
+	rm -rf import-test
 
 .PHONY: test-perf
 test-perf: clean

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,9 @@ setup(
     # ],
     test_suite='tests',
     extras_require={
+        ':python_version<"3"': [
+            'futures',
+        ],
         'tests': [
             'mock==1.0.1',
             'pycurl>=7.43,<8',


### PR DESCRIPTION
Futures is still needed as tornado.concurrent is an adapter, not a
backport, and threadloop directly imports concurrent.futures.

Use legacy env variable syntax that should work in ancient setuptools.

Fixes #177 