### PR TITLE
Use items instead of iteritems on Python 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ THRIFT_GEN_DIR=jaeger_client/thrift_gen
 THRIFT_VER=0.9.3
 THRIFT_IMG=thrift:$(THRIFT_VER)
 THRIFT_PY_ARGS=new_style,tornado
-THRIFT=docker run -v "${PWD}:/data" $(THRIFT_IMG) thrift
+THRIFT=docker run -v "${PWD}:/data" -u $(shell id -u) $(THRIFT_IMG) thrift
 
 idl-submodule:
 	git submodule init
@@ -96,4 +96,4 @@ thrift: idl-submodule thrift-image
 	done
 
 update-license:
-	python scripts/updateLicense.py $(sources)	
+	python scripts/updateLicense.py $(sources)

--- a/jaeger_client/thrift_gen/agent/Agent.py
+++ b/jaeger_client/thrift_gen/agent/Agent.py
@@ -5,6 +5,7 @@
 #
 #  options string: py:new_style,tornado
 #
+import six
 from six.moves import xrange
 
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException
@@ -209,7 +210,7 @@ class emitZipkinBatch_args(object):
 
   def __repr__(self):
     L = ['%s=%r' % (key, value)
-      for key, value in self.__dict__.iteritems()]
+      for key, value in six.iteritems(self.__dict__)]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
@@ -275,7 +276,7 @@ class emitBatch_args(object):
 
   def __repr__(self):
     L = ['%s=%r' % (key, value)
-      for key, value in self.__dict__.iteritems()]
+      for key, value in six.iteritems(self.__dict__)]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):

--- a/jaeger_client/thrift_gen/agent/constants.py
+++ b/jaeger_client/thrift_gen/agent/constants.py
@@ -5,6 +5,7 @@
 #
 #  options string: py:new_style,tornado
 #
+import six
 from six.moves import xrange
 
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException

--- a/jaeger_client/thrift_gen/agent/ttypes.py
+++ b/jaeger_client/thrift_gen/agent/ttypes.py
@@ -5,6 +5,7 @@
 #
 #  options string: py:new_style,tornado
 #
+import six
 from six.moves import xrange
 
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException

--- a/jaeger_client/thrift_gen/jaeger/Collector.py
+++ b/jaeger_client/thrift_gen/jaeger/Collector.py
@@ -5,6 +5,7 @@
 #
 #  options string: py:new_style,tornado
 #
+import six
 from six.moves import xrange
 
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException
@@ -199,7 +200,7 @@ class submitBatches_args(object):
 
   def __repr__(self):
     L = ['%s=%r' % (key, value)
-      for key, value in self.__dict__.iteritems()]
+      for key, value in six.iteritems(self.__dict__)]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
@@ -272,7 +273,7 @@ class submitBatches_result(object):
 
   def __repr__(self):
     L = ['%s=%r' % (key, value)
-      for key, value in self.__dict__.iteritems()]
+      for key, value in six.iteritems(self.__dict__)]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):

--- a/jaeger_client/thrift_gen/jaeger/constants.py
+++ b/jaeger_client/thrift_gen/jaeger/constants.py
@@ -5,6 +5,7 @@
 #
 #  options string: py:new_style,tornado
 #
+import six
 from six.moves import xrange
 
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException

--- a/jaeger_client/thrift_gen/jaeger/ttypes.py
+++ b/jaeger_client/thrift_gen/jaeger/ttypes.py
@@ -5,6 +5,7 @@
 #
 #  options string: py:new_style,tornado
 #
+import six
 from six.moves import xrange
 
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException
@@ -193,7 +194,7 @@ class Tag(object):
 
   def __repr__(self):
     L = ['%s=%r' % (key, value)
-      for key, value in self.__dict__.iteritems()]
+      for key, value in six.iteritems(self.__dict__)]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
@@ -284,7 +285,7 @@ class Log(object):
 
   def __repr__(self):
     L = ['%s=%r' % (key, value)
-      for key, value in self.__dict__.iteritems()]
+      for key, value in six.iteritems(self.__dict__)]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
@@ -396,7 +397,7 @@ class SpanRef(object):
 
   def __repr__(self):
     L = ['%s=%r' % (key, value)
-      for key, value in self.__dict__.iteritems()]
+      for key, value in six.iteritems(self.__dict__)]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
@@ -634,7 +635,7 @@ class Span(object):
 
   def __repr__(self):
     L = ['%s=%r' % (key, value)
-      for key, value in self.__dict__.iteritems()]
+      for key, value in six.iteritems(self.__dict__)]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
@@ -723,7 +724,7 @@ class Process(object):
 
   def __repr__(self):
     L = ['%s=%r' % (key, value)
-      for key, value in self.__dict__.iteritems()]
+      for key, value in six.iteritems(self.__dict__)]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
@@ -815,7 +816,7 @@ class Batch(object):
 
   def __repr__(self):
     L = ['%s=%r' % (key, value)
-      for key, value in self.__dict__.iteritems()]
+      for key, value in six.iteritems(self.__dict__)]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
@@ -882,7 +883,7 @@ class BatchSubmitResponse(object):
 
   def __repr__(self):
     L = ['%s=%r' % (key, value)
-      for key, value in self.__dict__.iteritems()]
+      for key, value in six.iteritems(self.__dict__)]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):

--- a/jaeger_client/thrift_gen/sampling/SamplingManager.py
+++ b/jaeger_client/thrift_gen/sampling/SamplingManager.py
@@ -5,6 +5,7 @@
 #
 #  options string: py:new_style,tornado
 #
+import six
 from six.moves import xrange
 
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException
@@ -190,7 +191,7 @@ class getSamplingStrategy_args(object):
 
   def __repr__(self):
     L = ['%s=%r' % (key, value)
-      for key, value in self.__dict__.iteritems()]
+      for key, value in six.iteritems(self.__dict__)]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
@@ -255,7 +256,7 @@ class getSamplingStrategy_result(object):
 
   def __repr__(self):
     L = ['%s=%r' % (key, value)
-      for key, value in self.__dict__.iteritems()]
+      for key, value in six.iteritems(self.__dict__)]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):

--- a/jaeger_client/thrift_gen/sampling/constants.py
+++ b/jaeger_client/thrift_gen/sampling/constants.py
@@ -5,6 +5,7 @@
 #
 #  options string: py:new_style,tornado
 #
+import six
 from six.moves import xrange
 
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException

--- a/jaeger_client/thrift_gen/sampling/ttypes.py
+++ b/jaeger_client/thrift_gen/sampling/ttypes.py
@@ -5,6 +5,7 @@
 #
 #  options string: py:new_style,tornado
 #
+import six
 from six.moves import xrange
 
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException
@@ -90,7 +91,7 @@ class ProbabilisticSamplingStrategy(object):
 
   def __repr__(self):
     L = ['%s=%r' % (key, value)
-      for key, value in self.__dict__.iteritems()]
+      for key, value in six.iteritems(self.__dict__)]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
@@ -157,7 +158,7 @@ class RateLimitingSamplingStrategy(object):
 
   def __repr__(self):
     L = ['%s=%r' % (key, value)
-      for key, value in self.__dict__.iteritems()]
+      for key, value in six.iteritems(self.__dict__)]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
@@ -240,7 +241,7 @@ class OperationSamplingStrategy(object):
 
   def __repr__(self):
     L = ['%s=%r' % (key, value)
-      for key, value in self.__dict__.iteritems()]
+      for key, value in six.iteritems(self.__dict__)]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
@@ -359,7 +360,7 @@ class PerOperationSamplingStrategies(object):
 
   def __repr__(self):
     L = ['%s=%r' % (key, value)
-      for key, value in self.__dict__.iteritems()]
+      for key, value in six.iteritems(self.__dict__)]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
@@ -468,7 +469,7 @@ class SamplingStrategyResponse(object):
 
   def __repr__(self):
     L = ['%s=%r' % (key, value)
-      for key, value in self.__dict__.iteritems()]
+      for key, value in six.iteritems(self.__dict__)]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):

--- a/jaeger_client/thrift_gen/zipkincore/ZipkinCollector.py
+++ b/jaeger_client/thrift_gen/zipkincore/ZipkinCollector.py
@@ -5,6 +5,7 @@
 #
 #  options string: py:new_style,tornado
 #
+import six
 from six.moves import xrange
 
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException
@@ -199,7 +200,7 @@ class submitZipkinBatch_args(object):
 
   def __repr__(self):
     L = ['%s=%r' % (key, value)
-      for key, value in self.__dict__.iteritems()]
+      for key, value in six.iteritems(self.__dict__)]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
@@ -272,7 +273,7 @@ class submitZipkinBatch_result(object):
 
   def __repr__(self):
     L = ['%s=%r' % (key, value)
-      for key, value in self.__dict__.iteritems()]
+      for key, value in six.iteritems(self.__dict__)]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):

--- a/jaeger_client/thrift_gen/zipkincore/constants.py
+++ b/jaeger_client/thrift_gen/zipkincore/constants.py
@@ -5,6 +5,7 @@
 #
 #  options string: py:new_style,tornado
 #
+import six
 from six.moves import xrange
 
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException

--- a/jaeger_client/thrift_gen/zipkincore/ttypes.py
+++ b/jaeger_client/thrift_gen/zipkincore/ttypes.py
@@ -5,6 +5,7 @@
 #
 #  options string: py:new_style,tornado
 #
+import six
 from six.moves import xrange
 
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException
@@ -158,7 +159,7 @@ class Endpoint(object):
 
   def __repr__(self):
     L = ['%s=%r' % (key, value)
-      for key, value in self.__dict__.iteritems()]
+      for key, value in six.iteritems(self.__dict__)]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
@@ -257,7 +258,7 @@ class Annotation(object):
 
   def __repr__(self):
     L = ['%s=%r' % (key, value)
-      for key, value in self.__dict__.iteritems()]
+      for key, value in six.iteritems(self.__dict__)]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
@@ -381,7 +382,7 @@ class BinaryAnnotation(object):
 
   def __repr__(self):
     L = ['%s=%r' % (key, value)
-      for key, value in self.__dict__.iteritems()]
+      for key, value in six.iteritems(self.__dict__)]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
@@ -617,7 +618,7 @@ class Span(object):
 
   def __repr__(self):
     L = ['%s=%r' % (key, value)
-      for key, value in self.__dict__.iteritems()]
+      for key, value in six.iteritems(self.__dict__)]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
@@ -684,7 +685,7 @@ class Response(object):
 
   def __repr__(self):
     L = ['%s=%r' % (key, value)
-      for key, value in self.__dict__.iteritems()]
+      for key, value in six.iteritems(self.__dict__)]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):

--- a/thrift-gen-fix.awk
+++ b/thrift-gen-fix.awk
@@ -1,14 +1,15 @@
-BEGIN {six=0; xrange=0}
+BEGIN {six=0}
 
 /^$/ {
-    # if in the future we need six, it can be added with the following line
-    # if (six == 0) print "import six"
+    if (six == 0) {
+        print "import six";
+        print "from six.moves import xrange";
+    }
     six = 1
-    if (xrange ==0) print "from six.moves import xrange"
-    xrange = 1
 }
 
 {
-        gsub(/from ttype/, "from .ttype",$0); 
-        print
+    gsub(/from ttype/, "from .ttype", $0);
+    gsub(/self.__dict__.iteritems\(\)/, "six.iteritems(self.__dict__)", $0);
+    print
 }


### PR DESCRIPTION
The generated thrift was using `__dict__.iteritems()` even on Python 3, so the awk script was updated to handle both Python 2 and 3.

Also the generated thrift output was without the user id set.