### PR TITLE
Preliminary refactor for supporting spans over HTTP

### DIFF
--- a/jaeger_client/config.py
+++ b/jaeger_client/config.py
@@ -340,6 +340,7 @@ class Config(object):
         Create a new Jaeger Tracer based on the passed `jaeger_client.Config`.
         Does not set `opentracing.tracer` global variable.
         """
+
         channel = self._create_local_agent_channel(io_loop=io_loop)
         sampler = self.sampler
         if not sampler:
@@ -360,7 +361,8 @@ class Config(object):
             flush_interval=self.reporter_flush_interval,
             logger=logger,
             metrics_factory=self._metrics_factory,
-            error_reporter=self.error_reporter)
+            error_reporter=self.error_reporter
+        )
 
         if self.logging:
             reporter = CompositeReporter(reporter, LoggingReporter(logger))

--- a/jaeger_client/local_agent_net.py
+++ b/jaeger_client/local_agent_net.py
@@ -69,6 +69,8 @@ class LocalAgentSender(TBufferedTransport):
         # IOLoop
         self._thread_loop = None
         self.io_loop = io_loop or self._create_new_thread_loop()
+        self.reporting_port = reporting_port
+        self.host = host
 
         # HTTP sampling
         self.local_agent_http = LocalAgentHTTP(host, sampling_port)

--- a/jaeger_client/senders.py
+++ b/jaeger_client/senders.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2018 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+
+import logging
+from threadloop import ThreadLoop
+
+from .local_agent_net import LocalAgentSender
+from thrift.protocol import TCompactProtocol
+
+from jaeger_client.thrift_gen.agent import Agent
+
+
+DEFAULT_SAMPLING_PORT = 5778
+
+logger = logging.getLogger('jaeger_tracing')
+
+
+class Sender(object):
+    def __init__(self, host, port, io_loop=None):
+        self.host = host
+        self.port = port
+        self.io_loop = io_loop or self._create_new_thread_loop()
+
+    def send(self, batch):
+        raise NotImplementedError('This method should be implemented by subclasses')
+
+    def _create_new_thread_loop(self):
+        """
+        Create a daemonized thread that will run Tornado IOLoop.
+        :return: the IOLoop backed by the new thread.
+        """
+        self._thread_loop = ThreadLoop()
+        if not self._thread_loop.is_ready():
+            self._thread_loop.start()
+        return self._thread_loop._io_loop
+
+
+class UDPSender(Sender):
+    def __init__(self, host, port, io_loop=None):
+        super(UDPSender, self).__init__(
+            host=host,
+            port=port,
+            io_loop=io_loop
+        )
+        self.channel = self._create_local_agent_channel(self.io_loop)
+        self.agent = Agent.Client(self.channel, self)
+
+    def send(self, batch):
+        """ Send batch of spans out via thrift transport.
+
+        Any exceptions thrown will be caught by the caller.
+        """
+
+        return self.agent.emitBatch(batch)
+
+    def _create_local_agent_channel(self, io_loop):
+        """
+        Create an out-of-process channel communicating to local jaeger-agent.
+        Spans are submitted as SOCK_DGRAM Thrift, sampling strategy is polled
+        via JSON HTTP.
+
+        :param self: instance of Config
+        """
+        logger.info('Initializing Jaeger Tracer with UDP reporter')
+        return LocalAgentSender(
+            host=self.host,
+            sampling_port=DEFAULT_SAMPLING_PORT,
+            reporting_port=self.port,
+            io_loop=io_loop
+        )
+
+    # method for protocol factory
+    def getProtocol(self, transport):
+        """
+        Implements Thrift ProtocolFactory interface
+        :param: transport:
+        :return: Thrift compact protocol
+        """
+        return TCompactProtocol.TCompactProtocol(transport)

--- a/tests/test_senders.py
+++ b/tests/test_senders.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2018 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import print_function
+
+
+import mock
+from tornado import ioloop
+
+from jaeger_client import senders
+from jaeger_client.local_agent_net import LocalAgentSender
+from jaeger_client.thrift_gen.agent import Agent
+from thrift.protocol import TCompactProtocol
+
+
+def test_base_sender_create_io_loop_if_not_provided():
+
+    sender = senders.Sender(host='mock', port=4242)
+
+    assert sender.io_loop is not None
+    assert isinstance(sender.io_loop, ioloop.IOLoop)
+
+def test_udp_sender_instantiate_thrift_agent():
+
+    sender = senders.UDPSender(host='mock', port=4242)
+
+    assert sender.agent is not None
+    assert isinstance(sender.agent, Agent.Client)
+
+
+def test_udp_sender_intantiate_local_agent_channel():
+
+    sender = senders.UDPSender(host='mock', port=4242)
+
+    assert sender.channel is not None
+    assert sender.channel.io_loop == sender.io_loop
+    assert isinstance(sender.channel, LocalAgentSender)
+
+def test_udp_sender_calls_agent_emitBatch_on_sending():
+
+    test_data = {'foo': 'bar'}
+    sender = senders.UDPSender(host='mock', port=4242)
+    sender.agent = mock.Mock()
+
+    sender.send(test_data)
+
+    sender.agent.emitBatch.assert_called_once_with(test_data)
+
+
+def test_udp_sender_implements_thrift_protocol_factory():
+
+    sender = senders.UDPSender(host='mock', port=4242)
+
+    assert callable(sender.getProtocol)
+    protocol = sender.getProtocol(mock.MagicMock())
+    assert isinstance(protocol, TCompactProtocol.TCompactProtocol)

--- a/tests/test_senders.py
+++ b/tests/test_senders.py
@@ -13,22 +13,116 @@
 # limitations under the License.
 from __future__ import print_function
 
+import time
+import socket
+import collections
 
 import mock
+import pytest
 from tornado import ioloop
+from tornado import gen
+from tornado.testing import AsyncTestCase, gen_test
 
 from jaeger_client import senders
+from jaeger_client import Span, SpanContext
 from jaeger_client.local_agent_net import LocalAgentSender
 from jaeger_client.thrift_gen.agent import Agent
+from jaeger_client.thrift_gen.jaeger import ttypes
 from thrift.protocol import TCompactProtocol
 
 
 def test_base_sender_create_io_loop_if_not_provided():
 
-    sender = senders.Sender(host='mock', port=4242)
+    sender = senders.Sender()
 
     assert sender.io_loop is not None
     assert isinstance(sender.io_loop, ioloop.IOLoop)
+
+
+def test_base_sender_send_not_implemented():
+    sender = senders.Sender()
+    with pytest.raises(NotImplementedError):
+        sender.send(1).result()
+
+
+def test_base_sender_set_process_instantiate_jaeger_process():
+    sender = senders.Sender()
+    sender.set_process('service', {}, max_length=0)
+    assert isinstance(sender._process, ttypes.Process)
+    assert sender._process.serviceName == 'service'
+
+
+def test_base_sender_spanless_flush_is_noop():
+    sender = senders.Sender()
+    flushed = sender.flush().result()
+    assert flushed is None
+
+    
+def test_base_sender_processless_flush_is_noop():
+    sender = senders.Sender()
+    sender.spans.append('foo')
+    flushed = sender.flush().result()
+    assert flushed is None
+
+
+class CustomException(Exception):
+    pass
+
+
+class SenderFlushTest(AsyncTestCase):
+
+    def span(self):
+        FakeTracer = collections.namedtuple('FakeTracer', ['ip_address', 'service_name'])
+        tracer = FakeTracer(ip_address='127.0.0.1', service_name='reporter_test')
+        ctx = SpanContext(trace_id=1, span_id=1, parent_id=None, flags=1)
+        span = Span(context=ctx, tracer=tracer, operation_name='foo')
+        span.start_time = time.time()
+        span.end_time = span.start_time + 0.001  # 1ms
+        return span
+
+    @gen_test
+    def test_base_sender_flush_raises_exceptions(self):
+        sender = senders.Sender()
+        sender.set_process('service', {}, max_length=0)
+
+        sender.spans = [self.span()]
+
+        sender.send = mock.MagicMock(side_effect=CustomException('Failed to send batch.'))
+        assert sender.span_count == 1
+
+        try:
+            yield sender.flush()
+        except Exception as exc:
+            assert isinstance(exc, CustomException)
+            assert str(exc) == 'Failed to send batch.'
+        else:
+            assert False, "Didn't Raise"
+        assert sender.span_count == 0
+
+    @gen_test
+    def test_udp_sender_flush_reraises_exceptions(self):
+        exceptions = ((CustomException, 'Failed to send batch.',
+                       'Failed to submit traces to jaeger-agent: Failed to send batch.'),
+                      (socket.error, 'Connection Failed',
+                       'Failed to submit traces to jaeger-agent socket: Connection Failed'))
+        for exception, value, expected_value in exceptions:
+            sender = senders.UDPSender(host='mock', port=4242)
+            sender.set_process('service', {}, max_length=0)
+
+            sender.spans = [self.span()]
+
+            sender.agent.emitBatch = mock.MagicMock(side_effect=exception(value))
+            assert sender.span_count == 1
+
+            try:
+                yield sender.flush()
+            except Exception as exc:
+                assert isinstance(exc, exception)
+                assert str(exc) == expected_value
+            else:
+                assert False, "Didn't Raise"
+            assert sender.span_count == 0
+
 
 def test_udp_sender_instantiate_thrift_agent():
 
@@ -46,7 +140,8 @@ def test_udp_sender_intantiate_local_agent_channel():
     assert sender.channel.io_loop == sender.io_loop
     assert isinstance(sender.channel, LocalAgentSender)
 
-def test_udp_sender_calls_agent_emitBatch_on_sending():
+
+def test_udp_sender_calls_agent_emitBatch_on_send():
 
     test_data = {'foo': 'bar'}
     sender = senders.UDPSender(host='mock', port=4242)


### PR DESCRIPTION
`Reporter` now delegate span sending to new `Sender` classes .

Related to https://github.com/jaegertracing/jaeger-client-python/pull/176 but made backwards compatible.

I'm not sure this is the best approach to solve backwards compatibility though

Signed-off-by: vitto <vittorio.camisa@gmail.com>