### PR TITLE
Add Zipkin API V2 Reporter

### DIFF
--- a/crossdock/server/endtoend.py
+++ b/crossdock/server/endtoend.py
@@ -28,7 +28,7 @@ from jaeger_client.constants import (
     SAMPLER_TYPE_REMOTE,
 )
 from jaeger_client.sampler import RemoteControlledSampler, ConstSampler
-from jaeger_client.reporter import Reporter
+from jaeger_client.reporter import ThriftReporter
 from jaeger_client.throttler import RemoteThrottler
 from jaeger_client.tracer import Tracer
 
@@ -67,8 +67,8 @@ class EndToEndHandler(object):
         init_sampler = cfg.sampler
         channel = self.local_agent_sender
 
-        reporter = Reporter(channel=channel,
-                            flush_interval=cfg.reporter_flush_interval)
+        reporter = ThriftReporter(channel=channel,
+                                  flush_interval=cfg.reporter_flush_interval)
 
         remote_sampler = RemoteControlledSampler(
             channel=channel,

--- a/jaeger_client/local_agent_net.py
+++ b/jaeger_client/local_agent_net.py
@@ -53,16 +53,12 @@ class LocalAgentHTTP(object):
         ] + [('operations', op) for op in operations])
 
 
-class LocalAgentSender(TBufferedTransport):
+class LocalAgentReader(object):
     """
-    LocalAgentSender implements everything necessary to communicate with
-    local jaeger-agent. This class is designed to work in tornado and
-    non-tornado environments. If in torndado, pass in the ioloop, if not
-    then LocalAgentSender will create one for itself.
-
-    NOTE: LocalAgentSender derives from TBufferedTransport. This will buffer
-    up all written data until flush() is called. Flush gets called at the
-    end of the batch span submission call.
+    LocalAgentReader implements what is necessary to obtain sampling strategies
+    and throttling credits from the local jaeger-agent.  This class is designed
+    to work in tornado and non-tornado environments. If in torndado, pass in the
+    ioloop, if not then LocalAgentSender will create one for itself.
     """
 
     def __init__(self, host, sampling_port, reporting_port, io_loop=None, throttling_port=None):
@@ -77,11 +73,6 @@ class LocalAgentSender(TBufferedTransport):
         if throttling_port:
             self.throttling_http = LocalAgentHTTP(host, throttling_port)
 
-        # UDP reporting - this will only get written to after our flush() call.
-        # We are buffering things up because we are a TBufferedTransport.
-        udp = TUDPTransport(host, reporting_port)
-        TBufferedTransport.__init__(self, udp)
-
     def _create_new_thread_loop(self):
         """
         Create a daemonized thread that will run Tornado IOLoop.
@@ -92,10 +83,6 @@ class LocalAgentSender(TBufferedTransport):
             self._thread_loop.start()
         return self._thread_loop._io_loop
 
-    def readFrame(self):
-        """Empty read frame that is never ready"""
-        return Future()
-
     # Pass-through for HTTP sampling strategies request.
     def request_sampling_strategy(self, *args, **kwargs):
         return self.local_agent_http.request_sampling_strategy(*args, **kwargs)
@@ -103,3 +90,26 @@ class LocalAgentSender(TBufferedTransport):
     # Pass-through for HTTP throttling credit request.
     def request_throttling_credits(self, *args, **kwargs):
         return self.throttling_http.request_throttling_credits(*args, **kwargs)
+
+
+class LocalAgentSender(LocalAgentReader, TBufferedTransport):
+    """
+    LocalAgentSender implements everything necessary to report spans to
+    the local jaeger-agent.
+
+    NOTE: LocalAgentSender derives from TBufferedTransport. This will buffer
+    up all written data until flush() is called. Flush gets called at the
+    end of the batch span submission call.
+    """
+
+    def __init__(self, host, sampling_port, reporting_port, io_loop=None, throttling_port=None):
+        LocalAgentReader.__init__(self, host, sampling_port, reporting_port,
+                                  io_loop, throttling_port)
+        # UDP reporting - this will only get written to after our flush() call.
+        # We are buffering things up because we are a TBufferedTransport.
+        udp = TUDPTransport(host, reporting_port)
+        TBufferedTransport.__init__(self, udp)
+
+    def readFrame(self):
+        """Empty read frame that is never ready"""
+        return Future()

--- a/jaeger_client/reporter.py
+++ b/jaeger_client/reporter.py
@@ -350,4 +350,4 @@ class ZipkinV2Reporter(QueueReporter):
             headers=headers,
             body=json.dumps(batch)
         )
-        client.fetch(request)
+        return client.fetch(request)

--- a/jaeger_client/zipkin_v2.py
+++ b/jaeger_client/zipkin_v2.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2018 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from binascii import hexlify
+from struct import pack
+import json
+
+from opentracing.ext import tags as ext_tags
+
+from jaeger_client.thrift_gen.jaeger.ttypes import TagType
+from .thrift import timestamp_micros
+from . import constants
+
+
+def make_zipkin_v2_batch(spans=None, process=None):
+    batched_spans = []
+    for span in spans:
+        with span.update_lock:
+            v2_span = to_zipkin_v2_span(span, process)
+        batched_spans.append(v2_span)
+    return batched_spans
+
+
+def to_zipkin_v2_span(span, process):
+    """Converts jaeger thrift span and process information to Zipkin's API v2 span format"""
+    v2_span = dict(
+        traceId=to_encoded_id(span.trace_id),
+        id=to_encoded_id(span.span_id),
+        timestamp=timestamp_micros(span.start_time),
+        debug=span.is_debug(),
+    )
+
+    if span.end_time:
+        v2_span['duration'] = timestamp_micros(span.end_time - span.start_time)
+
+    name = getattr(span, 'operation_name', '')
+    if name:
+        v2_span['name'] = name
+
+    parent_id = getattr(span, 'parent_id', 0)
+    if parent_id:
+        v2_span['parentId'] = to_encoded_id(parent_id)
+
+    kind = get_span_kind(span)
+    if kind:
+        v2_span['kind'] = kind
+
+    local_endpoint = get_local_endpoint(process)
+    if local_endpoint:
+        v2_span['localEndpoint'] = local_endpoint
+
+    remote_endpoint = get_remote_endpoint(process)
+    if remote_endpoint:
+        v2_span['remoteEndpoint'] = remote_endpoint
+
+    tags = format_span_tags(span)
+    if tags:
+        v2_span['tags'] = tags
+
+    annotations = [log_to_annotation(l) for l in span.logs]
+    if annotations:
+        v2_span['annotations'] = annotations
+
+    return v2_span
+
+
+def to_encoded_id(jaeger_id):
+    return hexlify(pack('>Q', jaeger_id)).decode('ascii')
+
+
+def get_span_kind(span):
+    kind = None
+    for tag in span.tags:
+        if tag.key == ext_tags.SPAN_KIND:
+            kind = {ext_tags.SPAN_KIND_RPC_CLIENT: 'CLIENT',
+                    ext_tags.SPAN_KIND_RPC_SERVER: 'SERVER'}[tag.vStr]
+    return kind
+
+
+ttype_attr_map = {TagType.BINARY: 'vBinary', TagType.BOOL: 'vBool', TagType.DOUBLE: 'vDouble',
+                  TagType.LONG: 'vLong', TagType.STRING: 'vStr'}
+
+
+def get_tag_value(tag):
+    attr = ttype_attr_map[tag.vType]
+    return getattr(tag, attr, None)
+
+
+def get_local_endpoint(process):
+    local_endpoint = {}
+    service_name = getattr(process, 'serviceName', '')
+    if service_name:
+        local_endpoint['serviceName'] = service_name
+    if process.tags:
+        for tag in process.tags:
+            if tag.key == constants.JAEGER_IP_TAG_KEY:
+                ipv4 = get_tag_value(tag)
+                if ipv4:
+                    local_endpoint['ipv4'] = ipv4
+                break
+    return local_endpoint
+
+
+def get_remote_endpoint(process):
+    tag_key_map = [(ext_tags.PEER_SERVICE, 'serviceName'), (ext_tags.PEER_HOST_IPV4, 'ipv4'),
+                   (ext_tags.PEER_HOST_IPV6, 'ipv6'), (ext_tags.PEER_PORT, 'port')]
+
+    remote_endpoint = {}
+    if process.tags:
+        for tag in process.tags:
+            for tag_key, endpoint_key in list(tag_key_map):
+                if tag.key == tag_key:
+                    tag_key_map.remove((tag_key, endpoint_key))
+                    value = get_tag_value(tag)
+                    if value:
+                        if tag.key == ext_tags.PEER_PORT:
+                            value = int(value)
+                        remote_endpoint[endpoint_key] = value
+                    continue
+            if not tag_key_map:
+                break
+
+    return remote_endpoint
+
+
+redundant_tags = (ext_tags.PEER_HOST_IPV4, ext_tags.PEER_HOST_IPV6, ext_tags.PEER_PORT,
+                  ext_tags.PEER_SERVICE, ext_tags.SPAN_KIND, ext_tags.SPAN_KIND_RPC_CLIENT,
+                  ext_tags.SPAN_KIND_RPC_SERVER)
+
+
+def format_span_tags(span):
+    formatted = {}
+    for tag in span.tags:
+        if tag.key not in redundant_tags:
+            k, v = format_span_tag(tag)
+            if v:
+                formatted[k] = v
+    return formatted
+
+
+def format_span_tag(tag):
+    key = tag.key
+    value = get_tag_value(tag)
+    return key, value
+
+
+def log_to_annotation(log):
+    annotation = dict(timestamp=log.timestamp)
+    tags = dict([format_span_tag(t) for t in log.fields])
+    annotation['value'] = json.dumps(tags)
+    return annotation

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -144,3 +144,22 @@ class ConfigTests(unittest.TestCase):
         tracer = c.initialize_tracer()
 
         assert opentracing.tracer == tracer
+
+    def test_reporter_type(self):
+        c = Config({'reporter_type': 'JaEGer'}, service_name='x')
+        assert c.reporter_type == 'jaeger'
+        c = Config({'reporter_type': 'ZiPKIn_V2'}, service_name='x')
+        assert c.reporter_type == 'zipkin_v2'
+
+    def test_headers(self):
+        c = Config({}, service_name='x')
+        assert c.headers == {}
+        cfg_dict = {'headers': {'HeaderOne': 'OneVal', 'HeaderTwo': 'TwoVal'}}
+        c = Config(cfg_dict, service_name='x')
+        assert c.headers == cfg_dict['headers']
+
+    def test_zipkin_spans_url(self):
+        c = Config({}, service_name='x')
+        assert c.zipkin_spans_url == 'http://localhost:9411/api/v2/spans'
+        c = Config({'zipkin_spans_url': 'someurl'}, service_name='x')
+        assert c.zipkin_spans_url == 'someurl'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,11 +19,15 @@ import opentracing.tracer
 from jaeger_client import Config, ConstSampler, ProbabilisticSampler, RateLimitingSampler
 from jaeger_client.config import DEFAULT_THROTTLER_PORT
 from jaeger_client.metrics import MetricsFactory
-from jaeger_client.reporter import NullReporter
+from jaeger_client.reporter import NullReporter, ZipkinV2Reporter
 from jaeger_client import constants
 
 
 class ConfigTests(unittest.TestCase):
+
+    def setUp(self):
+        if Config.initialized():
+            Config._initialized = False
 
     def test_enabled(self):
         c = Config({'enabled': True}, service_name='x')
@@ -142,14 +146,23 @@ class ConfigTests(unittest.TestCase):
     def test_initialize_tracer(self):
         c = Config({}, service_name='x')
         tracer = c.initialize_tracer()
-
         assert opentracing.tracer == tracer
+
+    def test_global_tracer_initializaion(self):
+        c = Config({}, service_name='x')
+        tracer = c.initialize_tracer()
+        assert tracer
+        attempt = c.initialize_tracer()
+        assert attempt is None
 
     def test_reporter_type(self):
         c = Config({'reporter_type': 'JaEGer'}, service_name='x')
         assert c.reporter_type == 'jaeger'
         c = Config({'reporter_type': 'ZiPKIn_V2'}, service_name='x')
         assert c.reporter_type == 'zipkin_v2'
+        c = Config({'reporter_type': 'NotAReporterType'}, service_name='x')
+        with self.assertRaises(ValueError):
+            c.reporter_type
 
     def test_headers(self):
         c = Config({}, service_name='x')
@@ -163,3 +176,9 @@ class ConfigTests(unittest.TestCase):
         assert c.zipkin_spans_url == 'http://localhost:9411/api/v2/spans'
         c = Config({'zipkin_spans_url': 'someurl'}, service_name='x')
         assert c.zipkin_spans_url == 'someurl'
+
+    def test_initialize_trace_with_zipkin_reporter(self):
+        c = Config({'reporter_type': 'zipkin_v2',
+                    'headers': {'Header': 'Value'}}, service_name='x')
+        tracer = c.initialize_tracer()
+        assert isinstance(tracer.reporter, ZipkinV2Reporter)

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -30,7 +30,7 @@ from jaeger_client.metrics import LegacyMetricsFactory, Metrics
 from jaeger_client.utils import ErrorReporter
 from tornado.ioloop import IOLoop
 from tornado.testing import AsyncTestCase, gen_test
-from jaeger_client.reporter import Reporter
+from jaeger_client.reporter import ThriftReporter
 from jaeger_client.ioloop_util import future_result
 
 
@@ -132,7 +132,7 @@ class FakeMetricsFactory(LegacyMetricsFactory):
         self.counters[key] = value + self.counters.get(key, 0)
 
 
-class ReporterTest(AsyncTestCase):
+class ThriftReporterTest(AsyncTestCase):
     @pytest.yield_fixture
     def thread_loop(self):
         yield
@@ -149,13 +149,13 @@ class ReporterTest(AsyncTestCase):
 
     @staticmethod
     def _new_reporter(batch_size, flush=None, queue_cap=100):
-        reporter = Reporter(channel=mock.MagicMock(),
-                            io_loop=IOLoop.current(),
-                            batch_size=batch_size,
-                            flush_interval=flush,
-                            metrics_factory=FakeMetricsFactory(),
-                            error_reporter=HardErrorReporter(),
-                            queue_capacity=queue_cap)
+        reporter = ThriftReporter(channel=mock.MagicMock(),
+                                  io_loop=IOLoop.current(),
+                                  batch_size=batch_size,
+                                  flush_interval=flush,
+                                  metrics_factory=FakeMetricsFactory(),
+                                  error_reporter=HardErrorReporter(),
+                                  queue_capacity=queue_cap)
         reporter.set_process('service', {}, max_length=0)
         sender = FakeSender()
         reporter._send = sender

--- a/tests/test_zipkin_v2.py
+++ b/tests/test_zipkin_v2.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2018 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+from time import time
+import json
+
+import mock
+
+from jaeger_client.zipkin_v2 import make_zipkin_v2_batch, to_zipkin_v2_span
+from jaeger_client import Span, SpanContext, ConstSampler
+import jaeger_client.thrift_gen.jaeger.ttypes as ttypes
+from jaeger_client.constants import JAEGER_IP_TAG_KEY
+from jaeger_client.thrift import timestamp_micros
+from opentracing.ext import tags as ext_tags
+from jaeger_client import thrift
+
+
+def to_tag(key, value):
+    return thrift.make_string_tag(key=key, value=value, max_length=100)
+
+
+def test_to_v2_span_no_parent_nor_duration_nor_tags_nor_annotations(tracer):
+    start_time = time()
+    ctx = SpanContext(trace_id=1, span_id=1, parent_id=None, flags=1)
+    span = Span(context=ctx, operation_name='operation', start_time=start_time, tracer=tracer)
+    process = ttypes.Process(serviceName='x')
+    zip_span = to_zipkin_v2_span(span, process)
+    expected = dict(debug=False, id='0000000000000001',
+                    traceId='0000000000000001',
+                    localEndpoint=dict(serviceName='x'),
+                    name='operation', timestamp=timestamp_micros(start_time))
+    assert zip_span == expected
+
+
+def test_to_v2_span_with_parent_no_duration_nor_tags_nor_annotations(tracer):
+    start_time = time()
+    ctx = SpanContext(trace_id=1, span_id=2, parent_id=1, flags=1)
+    span = Span(context=ctx, operation_name='operation', start_time=start_time, tracer=tracer)
+    process = ttypes.Process(serviceName='x', tags=[to_tag(JAEGER_IP_TAG_KEY, '127.0.0.1')])
+    zip_span = to_zipkin_v2_span(span, process)
+    expected = dict(debug=False, id='0000000000000002',
+                    parentId='0000000000000001', traceId='0000000000000001',
+                    localEndpoint=dict(serviceName='x', ipv4='127.0.0.1'),
+                    name='operation', timestamp=timestamp_micros(start_time))
+    assert zip_span == expected
+
+
+def test_to_v2_span_with_parent_and_duration_and_tags_no_annotations(tracer):
+    start_time = time()
+    ctx = SpanContext(trace_id=1, span_id=2, parent_id=1, flags=1)
+    span = Span(context=ctx, operation_name='operation', start_time=start_time, tracer=tracer)
+    span.set_tag('SomeKey', '123123')
+    span.set_tag(ext_tags.SPAN_KIND, ext_tags.SPAN_KIND_RPC_CLIENT)
+    end_time = start_time + 20
+    span.end_time = end_time
+    process = ttypes.Process(serviceName='x', tags=[to_tag(JAEGER_IP_TAG_KEY, '127.0.0.1')])
+    zip_span = to_zipkin_v2_span(span, process)
+    expected = dict(kind='CLIENT', debug=False, id='0000000000000002',
+                    parentId='0000000000000001', traceId='0000000000000001',
+                    localEndpoint=dict(serviceName='x', ipv4='127.0.0.1'),
+                    name='operation', timestamp=timestamp_micros(start_time),
+                    duration=20000000, tags=dict(SomeKey='123123'))
+    assert zip_span == expected
+
+
+def test_to_v2_span_with_parent_and_duration_and_tags_and_annotations(tracer):
+    start_time = time()
+    ctx = SpanContext(trace_id=18446744073709551614, span_id=18446744073709551615,
+                      parent_id=18446744073709551614, flags=1)
+    span = Span(context=ctx, operation_name='operation', start_time=start_time, tracer=tracer)
+    span.set_tag('SomeKey', '123123')
+    span.set_tag(ext_tags.SPAN_KIND, ext_tags.SPAN_KIND_RPC_SERVER)
+    event_time = time() + 3
+    span.log_kv({'SomeTagKey': 'SomeTagValue'}, timestamp=event_time)  
+    end_time = start_time + 20
+    span.end_time = end_time
+    process = ttypes.Process(serviceName='x', tags=[to_tag(JAEGER_IP_TAG_KEY, '127.0.0.1')])
+    zip_span = to_zipkin_v2_span(span, process)
+    expected = dict(kind='SERVER', debug=False, id='ffffffffffffffff',
+                    parentId='fffffffffffffffe', traceId='fffffffffffffffe',
+                    localEndpoint=dict(serviceName='x', ipv4='127.0.0.1'),
+                    name='operation', timestamp=timestamp_micros(start_time),
+                    duration=20000000, tags=dict(SomeKey='123123'),
+                    annotations=[dict(timestamp=timestamp_micros(event_time),
+                                      value=json.dumps(dict(SomeTagKey='SomeTagValue')))])
+    assert zip_span == expected
+
+
+def test_to_v2_span_remote_with_parent_and_duration_and_tags_and_annotations(tracer):
+    start_time = time()
+    ctx = SpanContext(trace_id=9205364235243340812, span_id=9830726033745040073,
+                      parent_id=9205364235243340812, flags=1)
+    span = Span(context=ctx, operation_name='operation', start_time=start_time, tracer=tracer)
+    span.set_tag('SomeKey', '123123')
+    event_time = time() + 3
+    span.log_kv({'SomeTagKey': 'SomeTagValue1'}, timestamp=event_time)  
+    span.log_kv({'SomeOtherTagKey': 'SomeTagValue2'}, timestamp=event_time + 1)  
+    span.log_kv({'SomeAdditionalTagKey': 'SomeTagValue3'}, timestamp=event_time + 2)  
+    end_time = start_time + 20
+    span.end_time = end_time
+    process = ttypes.Process(serviceName='x', tags=[
+        to_tag(JAEGER_IP_TAG_KEY, '127.0.0.1'),
+        to_tag(ext_tags.PEER_HOST_IPV4, '192.168.34.1'),
+        to_tag(ext_tags.PEER_HOST_IPV6, '::1'),
+        to_tag(ext_tags.PEER_SERVICE, 'remote_operation'),
+        to_tag(ext_tags.PEER_PORT, 99776),
+        to_tag('SomeOtherTag', 'TagValue')
+    ])
+
+    def is_debug(*args):  # simultaneously sampled and debug
+        return True
+
+    span.is_debug = is_debug
+    zip_span = to_zipkin_v2_span(span, process)
+
+    expected = dict(debug=True, id='886dc13e058ed2c9',
+                    parentId='7fc005fff5c3c40c', traceId='7fc005fff5c3c40c',
+                    localEndpoint=dict(serviceName='x', ipv4='127.0.0.1'),
+                    remoteEndpoint=dict(serviceName='remote_operation',
+                                        ipv4='192.168.34.1', ipv6='::1',
+                                        port=99776),
+                    name='operation', timestamp=timestamp_micros(start_time),
+                    duration=20000000, tags=dict(SomeKey='123123'),
+                    annotations=[
+                        dict(timestamp=timestamp_micros(event_time),
+                             value=json.dumps(dict(SomeTagKey='SomeTagValue1'))),
+                        dict(timestamp=timestamp_micros(event_time + 1),
+                             value=json.dumps(dict(SomeOtherTagKey='SomeTagValue2'))),
+                        dict(timestamp=timestamp_micros(event_time + 2),
+                             value=json.dumps(dict(SomeAdditionalTagKey='SomeTagValue3'))),
+                    ])
+    assert zip_span == expected
+
+
+def test_make_zipkin_v2_batch(tracer):
+    ctx_one = SpanContext(trace_id=1, span_id=1, parent_id=None, flags=1)
+    span_one = Span(context=ctx_one, operation_name='operation', start_time=time(), tracer=tracer)
+    ctx_two = SpanContext(trace_id=1, span_id=2, parent_id=1, flags=1)
+    span_two = Span(context=ctx_two, operation_name='operation', start_time=time(), tracer=tracer)
+    ctx_three = SpanContext(trace_id=1, span_id=3, parent_id=2, flags=1)
+    span_three = Span(context=ctx_three, operation_name='operation', start_time=time(), tracer=tracer)
+    process = ttypes.Process(serviceName='x', tags=[to_tag(JAEGER_IP_TAG_KEY, '127.0.0.1')])
+    batch = make_zipkin_v2_batch([span_one, span_two, span_three], process)
+    assert len(batch) == 3
+    assert batch[0]['id'] == '0000000000000001'
+    assert batch[1]['id'] == '0000000000000002'
+    assert batch[2]['id'] == '0000000000000003'


### PR DESCRIPTION
Expands span reporter selection by breaking out Reporter into base
QueueReporter class and using reporting method-specific ThriftReporter
and ZipkinV2Reporter.  Also breaks LocalAgentSender into two classes
including LocalAgentReader for ThriftReporter only usage of
TBufferedTransport.

These changes allow users to continue reporting spans oob to the local
jaeger-agent but with the option of reporting to Zipkin backend.

In the spirit of
https://github.com/jaegertracing/jaeger-client-java/pull/399
and
https://github.com/jaegertracing/jaeger-client-go/pull/310

Signed-off-by: Ryan Fitzpatrick <rmfitzpatrick@signalfx.com>