### PR TITLE
Fix incorrect default agent reporting port

### DIFF
--- a/jaeger_client/config.py
+++ b/jaeger_client/config.py
@@ -251,7 +251,7 @@ class Config(object):
         try:
             return int(os.getenv('JAEGER_AGENT_PORT'))
         except:
-            return DEFAULT_SAMPLING_PORT
+            return DEFAULT_REPORTING_PORT
 
     @property
     def local_agent_reporting_host(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -144,3 +144,7 @@ class ConfigTests(unittest.TestCase):
         tracer = c.initialize_tracer()
 
         assert opentracing.tracer == tracer
+
+    def test_default_local_agent_reporting_port(self):
+        c = Config({}, service_name='x')
+        assert c.local_agent_reporting_port == 6831


### PR DESCRIPTION
Corrects the returned default reporting port that was likely an
accident.

edit: Originally I had updated the evaluation order, but the config should take priority.

Signed-off-by: Ryan Fitzpatrick <rmfitzpatrick@signalfx.com>