### PR TITLE
Use opentracing 2.0

### DIFF
--- a/jaeger_client/config.py
+++ b/jaeger_client/config.py
@@ -84,17 +84,20 @@ class Config(object):
     _initialized_lock = threading.Lock()
 
     def __init__(self, config, metrics=None, service_name=None, metrics_factory=None,
-                 validate=False):
+                 validate=False, scope_manager=None):
         """
         :param metrics: an instance of Metrics class, or None. This parameter
             has been deprecated, please use metrics_factory instead.
         :param service_name: default service name.
             Can be overwritten by config['service_name'].
         :param metrics_factory: an instance of MetricsFactory class, or None.
+        :param scope_manager: a class implementing a scope manager, or None for
+            default (ThreadLocalScopeManager).
         """
         if validate:
             self._validate_config(config)
         self.config = config
+        self.scope_manager = scope_manager
         if get_boolean(self.config.get('metrics', True), True):
             self._metrics_factory = metrics_factory or LegacyMetricsFactory(metrics or Metrics())
         else:
@@ -413,6 +416,7 @@ class Config(object):
             max_tag_value_length=self.max_tag_value_length,
             extra_codecs=self.propagation,
             throttler=throttler,
+            scope_manager=self.scope_manager,
         )
 
     def _initialize_global_tracer(self, tracer):

--- a/jaeger_client/config.py
+++ b/jaeger_client/config.py
@@ -91,7 +91,7 @@ class Config(object):
         :param service_name: default service name.
             Can be overwritten by config['service_name'].
         :param metrics_factory: an instance of MetricsFactory class, or None.
-        :param scope_manager: a class implementing a scope manager, or None for
+        :param scope_manager: an instance of a scope manager, or None for
             default (ThreadLocalScopeManager).
         """
         if validate:

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -142,9 +142,8 @@ class Tracer(opentracing.Tracer):
         """
         parent = child_of
 
-        active_span = self.active_span
-        if parent is None and not ignore_active_span:
-            parent = active_span
+        if self.active_span is not None and not ignore_active_span:
+            parent = self.active_span
 
         if references:
             if isinstance(references, list):

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -123,7 +123,8 @@ class Tracer(opentracing.Tracer):
                    references=None,
                    tags=None,
                    start_time=None,
-                   ignore_active_span=False):
+                   ignore_active_span=False,
+    ):
         """
         Start and return a new Span representing a unit of work.
 
@@ -211,7 +212,8 @@ class Tracer(opentracing.Tracer):
                           tags=None,
                           start_time=None,
                           ignore_active_span=False,
-                          finish_on_close=True):
+                          finish_on_close=True,
+    ):
         """
         Returns a newly started and activated :class:`Scope`
 

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -112,8 +112,7 @@ class Tracer(opentracing.Tracer):
         )
 
         super(Tracer, self).__init__(
-            scope_manager=scope_manager() if scope_manager
-            else ThreadLocalScopeManager()
+            scope_manager=scope_manager or ThreadLocalScopeManager()
         )
 
     def start_span(self,

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -144,9 +144,9 @@ class Tracer(opentracing.Tracer):
         """
         parent = child_of
 
-        if (self.active_span is not None and
-                not ignore_active_span and
-                not parent):
+        if self.active_span is not None \
+                and not ignore_active_span \
+                and not parent:
             parent = self.active_span
 
         if references:

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -52,7 +52,7 @@ class Tracer(opentracing.Tracer):
         tags=None,
         max_tag_value_length=constants.MAX_TAG_VALUE_LENGTH,
         throttler=None,
-        scope_manager=ThreadLocalScopeManager,
+        scope_manager=None,
     ):
         self.service_name = service_name
         self.reporter = reporter
@@ -112,7 +112,10 @@ class Tracer(opentracing.Tracer):
             max_length=self.max_tag_value_length,
         )
 
-        super(Tracer, self).__init__(scope_manager=scope_manager())
+        super(Tracer, self).__init__(
+            scope_manager=scope_manager() if scope_manager
+            else ThreadLocalScopeManager()
+        )
 
     def start_span(self,
                    operation_name=None,

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -123,7 +123,7 @@ class Tracer(opentracing.Tracer):
                    tags=None,
                    start_time=None,
                    ignore_active_span=False,
-    ):
+                   ):
         """
         Start and return a new Span representing a unit of work.
 
@@ -212,7 +212,7 @@ class Tracer(opentracing.Tracer):
                           start_time=None,
                           ignore_active_span=False,
                           finish_on_close=True,
-    ):
+                          ):
         """
         Returns a newly started and activated :class:`Scope`
 
@@ -243,7 +243,6 @@ class Tracer(opentracing.Tracer):
             ignore_active_span,
         )
         return self.scope_manager.activate(span, finish_on_close)
-
 
     def inject(self, span_context, format, carrier):
         codec = self.codecs.get(format, None)

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -89,7 +89,6 @@ class Tracer(opentracing.Tracer):
         if tags:
             self.tags.update(tags)
 
-
         if self.tags.get(constants.JAEGER_IP_TAG_KEY) is None:
             self.tags[constants.JAEGER_IP_TAG_KEY] = local_ip()
 

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -144,7 +144,9 @@ class Tracer(opentracing.Tracer):
         """
         parent = child_of
 
-        if self.active_span is not None and not ignore_active_span:
+        if (self.active_span is not None and
+                not ignore_active_span and
+                not parent):
             parent = self.active_span
 
         if references:

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -234,12 +234,12 @@ class Tracer(opentracing.Tracer):
         :return: a :class:`Scope`, already registered via the :class:`ScopeManager`.
         """
         span = self.start_span(
-            operation_name,
-            child_of,
-            references,
-            tags,
-            start_time,
-            ignore_active_span,
+            operation_name=operation_name,
+            child_of=child_of,
+            references=references,
+            tags=tags,
+            start_time=start_time,
+            ignore_active_span=ignore_active_span,
         )
         return self.scope_manager.activate(span, finish_on_close)
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'threadloop>=1,<2',
         'thrift',
         'tornado>=4.3,<5',
-        'opentracing>=1.2.2,<2',
+        'opentracing>=2.0,<2.1',
     ],
     # Uncomment below if need to test with unreleased version of opentracing
     # dependency_links=[

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'threadloop>=1,<2',
         'thrift',
         'tornado>=4.3,<5',
-        'opentracing>=2.0,<2.1',
+        'opentracing>=2.0,<3.0',
     ],
     # Uncomment below if need to test with unreleased version of opentracing
     # dependency_links=[

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'threadloop>=1,<2',
         'thrift',
         'tornado>=4.3,<5',
-        'opentracing>=2.0,<3.0',
+        'opentracing>=2.1,<3.0',
     ],
     # Uncomment below if need to test with unreleased version of opentracing
     # dependency_links=[

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -36,7 +36,7 @@ class APITest(unittest.TestCase, APICompatibilityCheckMixin):
         pass
 
     def is_parent(self, parent, span):
-        return span.parent_id == getattr(parent, "span_id", None)
+        return span.parent_id == getattr(parent, 'span_id', None)
 
     # NOTE: this overrides a method defined in ApiComaptibilityCheckMixin in
     # order to add the scope.close() call, which prevents the tracer from

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -41,8 +41,9 @@ class APITest(unittest.TestCase, APICompatibilityCheckMixin):
     # NOTE: this overrides a method defined in ApiComaptibilityCheckMixin in
     # order to add the scope.close() call, which prevents the tracer from
     # leaving an active scope in thread local storage
-    # TODO: remove after
-    # https://github.com/opentracing/opentracing-python/issues/117 is fixed
+    # TODO: remove after switching to opentracing-python 2.1.0, issue for
+    # tracking the release:
+    # https://github.com/opentracing/opentracing-python/issues/119
     def test_start_active_span(self):
         # the first usage returns a `Scope` that wraps a root `Span`
         tracer = self.tracer()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -41,7 +41,7 @@ class APITest(unittest.TestCase, APICompatibilityCheckMixin):
     # NOTE: this overrides a method defined in ApiComaptibilityCheckMixin in
     # order to add the scope.close() call, which prevents the tracer from
     # leaving an active scope in thread local storage
-    # TODO: remove after 
+    # TODO: remove after
     # https://github.com/opentracing/opentracing-python/issues/117 is fixed
     def test_start_active_span(self):
         # the first usage returns a `Scope` that wraps a root `Span`

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -37,20 +37,3 @@ class APITest(unittest.TestCase, APICompatibilityCheckMixin):
 
     def is_parent(self, parent, span):
         return span.parent_id == getattr(parent, 'span_id', None)
-
-    # NOTE: this overrides a method defined in ApiComaptibilityCheckMixin in
-    # order to add the scope.close() call, which prevents the tracer from
-    # leaving an active scope in thread local storage
-    # TODO: remove after switching to opentracing-python 2.1.0, issue for
-    # tracking the release:
-    # https://github.com/opentracing/opentracing-python/issues/119
-    def test_start_active_span(self):
-        # the first usage returns a `Scope` that wraps a root `Span`
-        tracer = self.tracer()
-        scope = tracer.start_active_span('Fry')
-
-        assert scope.span is not None
-        if self.check_scope_manager():
-            assert self.is_parent(None, scope.span)
-
-        scope.close()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -41,6 +41,8 @@ class APITest(unittest.TestCase, APICompatibilityCheckMixin):
     # NOTE: this overrides a method defined in ApiComaptibilityCheckMixin in
     # order to add the scope.close() call, which prevents the tracer from
     # leaving an active scope in thread local storage
+    # TODO: remove after 
+    # https://github.com/opentracing/opentracing-python/issues/117 is fixed
     def test_start_active_span(self):
         # the first usage returns a `Scope` that wraps a root `Span`
         tracer = self.tracer()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -37,3 +37,17 @@ class APITest(unittest.TestCase, APICompatibilityCheckMixin):
 
     def is_parent(self, parent, span):
         return span.parent_id == getattr(parent, "span_id", None)
+
+    # NOTE: this overrides a method defined in ApiComaptibilityCheckMixin in
+    # order to add the scope.close() call, which prevents the tracer from
+    # leaving an active scope in thread local storage
+    def test_start_active_span(self):
+        # the first usage returns a `Scope` that wraps a root `Span`
+        tracer = self.tracer()
+        scope = tracer.start_active_span('Fry')
+
+        assert scope.span is not None
+        if self.check_scope_manager():
+            assert self.is_parent(None, scope.span)
+
+        scope.close()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -34,3 +34,6 @@ class APITest(unittest.TestCase, APICompatibilityCheckMixin):
     def test_binary_propagation(self):
         # TODO binary codecs are not implemented at the moment
         pass
+
+    def is_parent(self, parent, span):
+        return span.parent_id == getattr(parent, "span_id", None)


### PR DESCRIPTION
This pull request bumps `opntracing` to 2.0 and implements changes needed for api compatibility (mainly regarding scope managers). I assumed compatibility with 2.x only, but maybe it would be possible to run it with 1.x as well, not sure if that is a good idea though. 
I used `ThreadLocalScopeManager` from `opentracing` as a default scope manager.

The tests may fail because of an `opentracing` issue I fixed in https://github.com/opentracing/opentracing-python/pull/97 

Resolves #199 