### PR TITLE
Initial Sender implementation

### DIFF
--- a/jaeger_client/config.py
+++ b/jaeger_client/config.py
@@ -346,6 +346,7 @@ class Config(object):
         Create a new Jaeger Tracer based on the passed `jaeger_client.Config`.
         Does not set `opentracing.tracer` global variable.
         """
+
         channel = self._create_local_agent_channel(io_loop=io_loop)
         sampler = self.sampler
         if not sampler:
@@ -366,7 +367,8 @@ class Config(object):
             flush_interval=self.reporter_flush_interval,
             logger=logger,
             metrics_factory=self._metrics_factory,
-            error_reporter=self.error_reporter)
+            error_reporter=self.error_reporter
+        )
 
         if self.logging:
             reporter = CompositeReporter(reporter, LoggingReporter(logger))

--- a/jaeger_client/local_agent_net.py
+++ b/jaeger_client/local_agent_net.py
@@ -69,6 +69,8 @@ class LocalAgentSender(TBufferedTransport):
         # IOLoop
         self._thread_loop = None
         self.io_loop = io_loop or self._create_new_thread_loop()
+        self.reporting_port = reporting_port
+        self.host = host
 
         # HTTP sampling
         self.local_agent_http = LocalAgentHTTP(host, sampling_port)

--- a/jaeger_client/local_agent_net.py
+++ b/jaeger_client/local_agent_net.py
@@ -69,8 +69,8 @@ class LocalAgentSender(TBufferedTransport):
         # IOLoop
         self._thread_loop = None
         self.io_loop = io_loop or self._create_new_thread_loop()
-        self.reporting_port = reporting_port
-        self.host = host
+        self._reporting_port = reporting_port
+        self._host = host
 
         # HTTP sampling
         self.local_agent_http = LocalAgentHTTP(host, sampling_port)

--- a/jaeger_client/reporter.py
+++ b/jaeger_client/reporter.py
@@ -24,6 +24,7 @@ from tornado.concurrent import Future
 from .constants import DEFAULT_FLUSH_INTERVAL
 from . import ioloop_util
 from .metrics import Metrics, LegacyMetricsFactory
+from jaeger_client.thrift_gen.agent import Agent
 from .senders import UDPSender
 from .utils import ErrorReporter
 
@@ -97,7 +98,13 @@ class Reporter(NullReporter):
         from threading import Lock
 
         # TODO for next major rev: remove channel param in favor of sender
-        self._sender = sender or self._create_default_sender(channel)
+        self.agent = Agent.Client(channel, self)
+        self._sender = sender or UDPSender(
+            port=channel._reporting_port,
+            host=channel._host,
+            io_loop=channel.io_loop,
+            agent=self.agent
+        )
         self.queue_capacity = queue_capacity
         self.batch_size = batch_size
         self.metrics_factory = metrics_factory or LegacyMetricsFactory(metrics or Metrics())
@@ -108,36 +115,24 @@ class Reporter(NullReporter):
         if queue_capacity < batch_size:
             raise ValueError('Queue capacity cannot be less than batch size')
 
-        self.io_loop = io_loop or self.fetch_io_loop(channel, self._sender)
-
-        if self.io_loop is None:
-            self.logger.error('Jaeger Reporter has no IOLoop')
+        if io_loop:
+            self.io_loop = io_loop
         else:
-            self.queue = tornado.queues.Queue(maxsize=queue_capacity)
-            self.stop = object()
-            self.stopped = False
-            self.stop_lock = Lock()
-            self.flush_interval = flush_interval or None
-            self.io_loop.spawn_callback(self._consume_queue)
+            self.io_loop = self._sender._io_loop
 
-    @staticmethod
-    def fetch_io_loop(channel, sender):
-        if channel:
-            return channel.io_loop
-        elif sender:
-            return sender.io_loop
-        return None
-
-    def _create_default_sender(self, channel):
-        sender = UDPSender(
-            port=channel.reporting_port,
-            host=channel.host,
-            io_loop=channel.io_loop
-        )
-        return sender
+        self.queue = tornado.queues.Queue(maxsize=queue_capacity)
+        self.stop = object()
+        self.stopped = False
+        self.stop_lock = Lock()
+        self.flush_interval = flush_interval or None
+        self.io_loop.spawn_callback(self._consume_queue)
 
     def set_process(self, service_name, tags, max_length):
         self._sender.set_process(service_name, tags, max_length)
+
+    # method for protocol factory
+    def getProtocol(self, transport):
+        return self._sender.getProtocol(transport)
 
     def report_span(self, span):
         # We should not be calling `queue.put_nowait()` from random threads,

--- a/jaeger_client/senders.py
+++ b/jaeger_client/senders.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2018 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+
+import logging
+from threadloop import ThreadLoop
+
+from .local_agent_net import LocalAgentSender
+from thrift.protocol import TCompactProtocol
+
+from jaeger_client.thrift_gen.agent import Agent
+
+
+DEFAULT_SAMPLING_PORT = 5778
+
+logger = logging.getLogger('jaeger_tracing')
+
+
+class Sender(object):
+    def __init__(self, host, port, io_loop=None):
+        self.host = host
+        self.port = port
+        self.io_loop = io_loop or self._create_new_thread_loop()
+
+    def send(self, batch):
+        raise NotImplementedError('This method should be implemented by subclasses')
+
+    def _create_new_thread_loop(self):
+        """
+        Create a daemonized thread that will run Tornado IOLoop.
+        :return: the IOLoop backed by the new thread.
+        """
+        self._thread_loop = ThreadLoop()
+        if not self._thread_loop.is_ready():
+            self._thread_loop.start()
+        return self._thread_loop._io_loop
+
+
+class UDPSender(Sender):
+    def __init__(self, host, port, io_loop=None):
+        super(UDPSender, self).__init__(
+            host=host,
+            port=port,
+            io_loop=io_loop
+        )
+        self.channel = self._create_local_agent_channel(self.io_loop)
+        self.agent = Agent.Client(self.channel, self)
+
+    def send(self, batch):
+        """ Send batch of spans out via thrift transport.
+
+        Any exceptions thrown will be caught by the caller.
+        """
+
+        return self.agent.emitBatch(batch)
+
+    def _create_local_agent_channel(self, io_loop):
+        """
+        Create an out-of-process channel communicating to local jaeger-agent.
+        Spans are submitted as SOCK_DGRAM Thrift, sampling strategy is polled
+        via JSON HTTP.
+
+        :param self: instance of Config
+        """
+        logger.info('Initializing Jaeger Tracer with UDP reporter')
+        return LocalAgentSender(
+            host=self.host,
+            sampling_port=DEFAULT_SAMPLING_PORT,
+            reporting_port=self.port,
+            io_loop=io_loop
+        )
+
+    # method for protocol factory
+    def getProtocol(self, transport):
+        """
+        Implements Thrift ProtocolFactory interface
+        :param: transport:
+        :return: Thrift compact protocol
+        """
+        return TCompactProtocol.TCompactProtocol(transport)

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -96,7 +96,7 @@ def test_composite_reporter():
 
 class FakeSender(object):
     """
-    Mock the _send() method of the reporter by capturing requests
+    Mock the send() method of the reporter's Sender by capturing requests
     and returning incomplete futures that can be completed from
     inside the test.
     """
@@ -163,7 +163,7 @@ class ReporterTest(AsyncTestCase):
                             queue_capacity=queue_cap)
         reporter.set_process('service', {}, max_length=0)
         sender = FakeSender()
-        reporter._send = sender
+        reporter._sender.send = sender
         return reporter, sender
 
     @tornado.gen.coroutine
@@ -203,16 +203,11 @@ class ReporterTest(AsyncTestCase):
         reporter_failure_key = 'jaeger:reporter_spans.result_err'
         assert reporter_failure_key not in reporter.metrics_factory.counters
 
-        # simulate exception in send
-        reporter._send = mock.MagicMock(side_effect=ValueError())
+        reporter._sender.send = mock.MagicMock(side_effect=ValueError())
         reporter.report_span(self._new_span('1'))
-
         yield self._wait_for(
             lambda: reporter_failure_key in reporter.metrics_factory.counters)
         assert 1 == reporter.metrics_factory.counters.get(reporter_failure_key)
-
-        # silly test, for code coverage only
-        yield reporter._submit([])
 
     @gen_test
     def test_submit_queue_full_batch_size_1(self):
@@ -280,7 +275,7 @@ class ReporterTest(AsyncTestCase):
             count[0] += 1
             return future_result(True)
 
-        reporter._send = send
+        reporter._sender.send = send
         reporter.batch_size = 3
         for i in range(10):
             reporter.report_span(self._new_span('%s' % i))
@@ -299,22 +294,6 @@ class ReporterTest(AsyncTestCase):
 
 
 class TestReporterUnit:
-    def test_reporter_calls_sender_correctly(self):
-        reporter = Reporter(
-            channel=None,
-            sender=mock.MagicMock(),
-            io_loop=IOLoop.current(),
-            batch_size=10,
-            flush_interval=None,
-            metrics_factory=FakeMetricsFactory(),
-            error_reporter=HardErrorReporter(),
-            queue_capacity=100
-        )
-        test_data = {'foo': 'bar'}
-
-        reporter._send(test_data)
-        reporter._sender.send.assert_called_once_with(test_data)
-
     @pytest.mark.parametrize(
         'channel, sender, expected',
         [

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -294,19 +294,9 @@ class ReporterTest(AsyncTestCase):
 
 
 class TestReporterUnit:
-    @pytest.mark.parametrize(
-        'channel, sender, expected',
-        [
-            (None, None, None),
-            (None, type('X', (object,), {'io_loop': 'foo'}), 'foo'),
-            (type('X', (object,), {'io_loop': 'bar'}), None, 'bar'),
-            (
-                type('X', (object,), {'io_loop': 'bar'}),
-                type('X', (object,), {'io_loop': 'foo'}),
-                'bar'
-            ),
-        ]
-    )
-    def test_reporter_fetch_io_loop_works_as_expected(self, channel, sender, expected):
-        result = Reporter.fetch_io_loop(channel, sender)
-        assert expected == result
+
+    def test_reporter_obtains_io_loop_from_sender(self):
+        channel = mock.MagicMock()
+        sender = mock.MagicMock()
+        reporter = Reporter(channel=channel, sender=sender)
+        assert reporter.io_loop == sender._io_loop, "Reporter didn't set its io_loop from Sender's"

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -296,3 +296,38 @@ class ReporterTest(AsyncTestCase):
         yield reporter.close()
         assert reporter.queue.qsize() == 0, 'all spans drained'
         assert count[0] == 4, 'last span submitted in one extrac batch'
+
+
+class TestReporterUnit:
+    def test_reporter_calls_sender_correctly(self):
+        reporter = Reporter(
+            channel=None,
+            sender=mock.MagicMock(),
+            io_loop=IOLoop.current(),
+            batch_size=10,
+            flush_interval=None,
+            metrics_factory=FakeMetricsFactory(),
+            error_reporter=HardErrorReporter(),
+            queue_capacity=100
+        )
+        test_data = {'foo': 'bar'}
+
+        reporter._send(test_data)
+        reporter._sender.send.assert_called_once_with(test_data)
+
+    @pytest.mark.parametrize(
+        'channel, sender, expected',
+        [
+            (None, None, None),
+            (None, type('X', (object,), {'io_loop': 'foo'}), 'foo'),
+            (type('X', (object,), {'io_loop': 'bar'}), None, 'bar'),
+            (
+                type('X', (object,), {'io_loop': 'bar'}),
+                type('X', (object,), {'io_loop': 'foo'}),
+                'bar'
+            ),
+        ]
+    )
+    def test_reporter_fetch_io_loop_works_as_expected(self, channel, sender, expected):
+        result = Reporter.fetch_io_loop(channel, sender)
+        assert expected == result

--- a/tests/test_senders.py
+++ b/tests/test_senders.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2018 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import print_function
+
+
+import mock
+from tornado import ioloop
+
+from jaeger_client import senders
+from jaeger_client.local_agent_net import LocalAgentSender
+from jaeger_client.thrift_gen.agent import Agent
+from thrift.protocol import TCompactProtocol
+
+
+def test_base_sender_create_io_loop_if_not_provided():
+
+    sender = senders.Sender(host='mock', port=4242)
+
+    assert sender.io_loop is not None
+    assert isinstance(sender.io_loop, ioloop.IOLoop)
+
+def test_udp_sender_instantiate_thrift_agent():
+
+    sender = senders.UDPSender(host='mock', port=4242)
+
+    assert sender.agent is not None
+    assert isinstance(sender.agent, Agent.Client)
+
+
+def test_udp_sender_intantiate_local_agent_channel():
+
+    sender = senders.UDPSender(host='mock', port=4242)
+
+    assert sender.channel is not None
+    assert sender.channel.io_loop == sender.io_loop
+    assert isinstance(sender.channel, LocalAgentSender)
+
+def test_udp_sender_calls_agent_emitBatch_on_sending():
+
+    test_data = {'foo': 'bar'}
+    sender = senders.UDPSender(host='mock', port=4242)
+    sender.agent = mock.Mock()
+
+    sender.send(test_data)
+
+    sender.agent.emitBatch.assert_called_once_with(test_data)
+
+
+def test_udp_sender_implements_thrift_protocol_factory():
+
+    sender = senders.UDPSender(host='mock', port=4242)
+
+    assert callable(sender.getProtocol)
+    protocol = sender.getProtocol(mock.MagicMock())
+    assert isinstance(protocol, TCompactProtocol.TCompactProtocol)

--- a/tests/test_senders.py
+++ b/tests/test_senders.py
@@ -13,22 +13,116 @@
 # limitations under the License.
 from __future__ import print_function
 
+import time
+import socket
+import collections
 
 import mock
+import pytest
 from tornado import ioloop
+from tornado import gen
+from tornado.testing import AsyncTestCase, gen_test
 
 from jaeger_client import senders
+from jaeger_client import Span, SpanContext
 from jaeger_client.local_agent_net import LocalAgentSender
 from jaeger_client.thrift_gen.agent import Agent
+from jaeger_client.thrift_gen.jaeger import ttypes
 from thrift.protocol import TCompactProtocol
 
 
 def test_base_sender_create_io_loop_if_not_provided():
 
-    sender = senders.Sender(host='mock', port=4242)
+    sender = senders.Sender()
 
     assert sender.io_loop is not None
     assert isinstance(sender.io_loop, ioloop.IOLoop)
+
+
+def test_base_sender_send_not_implemented():
+    sender = senders.Sender()
+    with pytest.raises(NotImplementedError):
+        sender.send(1).result()
+
+
+def test_base_sender_set_process_instantiate_jaeger_process():
+    sender = senders.Sender()
+    sender.set_process('service', {}, max_length=0)
+    assert isinstance(sender._process, ttypes.Process)
+    assert sender._process.serviceName == 'service'
+
+
+def test_base_sender_spanless_flush_is_noop():
+    sender = senders.Sender()
+    flushed = sender.flush().result()
+    assert flushed is None
+
+    
+def test_base_sender_processless_flush_is_noop():
+    sender = senders.Sender()
+    sender.spans.append('foo')
+    flushed = sender.flush().result()
+    assert flushed is None
+
+
+class CustomException(Exception):
+    pass
+
+
+class SenderFlushTest(AsyncTestCase):
+
+    def span(self):
+        FakeTracer = collections.namedtuple('FakeTracer', ['ip_address', 'service_name'])
+        tracer = FakeTracer(ip_address='127.0.0.1', service_name='reporter_test')
+        ctx = SpanContext(trace_id=1, span_id=1, parent_id=None, flags=1)
+        span = Span(context=ctx, tracer=tracer, operation_name='foo')
+        span.start_time = time.time()
+        span.end_time = span.start_time + 0.001  # 1ms
+        return span
+
+    @gen_test
+    def test_base_sender_flush_raises_exceptions(self):
+        sender = senders.Sender()
+        sender.set_process('service', {}, max_length=0)
+
+        sender.spans = [self.span()]
+
+        sender.send = mock.MagicMock(side_effect=CustomException('Failed to send batch.'))
+        assert sender.span_count == 1
+
+        try:
+            yield sender.flush()
+        except Exception as exc:
+            assert isinstance(exc, CustomException)
+            assert str(exc) == 'Failed to send batch.'
+        else:
+            assert False, "Didn't Raise"
+        assert sender.span_count == 0
+
+    @gen_test
+    def test_udp_sender_flush_reraises_exceptions(self):
+        exceptions = ((CustomException, 'Failed to send batch.',
+                       'Failed to submit traces to jaeger-agent: Failed to send batch.'),
+                      (socket.error, 'Connection Failed',
+                       'Failed to submit traces to jaeger-agent socket: Connection Failed'))
+        for exception, value, expected_value in exceptions:
+            sender = senders.UDPSender(host='mock', port=4242)
+            sender.set_process('service', {}, max_length=0)
+
+            sender.spans = [self.span()]
+
+            sender.agent.emitBatch = mock.MagicMock(side_effect=exception(value))
+            assert sender.span_count == 1
+
+            try:
+                yield sender.flush()
+            except Exception as exc:
+                assert isinstance(exc, exception)
+                assert str(exc) == expected_value
+            else:
+                assert False, "Didn't Raise"
+            assert sender.span_count == 0
+
 
 def test_udp_sender_instantiate_thrift_agent():
 
@@ -46,7 +140,8 @@ def test_udp_sender_intantiate_local_agent_channel():
     assert sender.channel.io_loop == sender.io_loop
     assert isinstance(sender.channel, LocalAgentSender)
 
-def test_udp_sender_calls_agent_emitBatch_on_sending():
+
+def test_udp_sender_calls_agent_emitBatch_on_send():
 
     test_data = {'foo': 'bar'}
     sender = senders.UDPSender(host='mock', port=4242)

--- a/tests/test_senders.py
+++ b/tests/test_senders.py
@@ -20,7 +20,6 @@ import collections
 import mock
 import pytest
 from tornado import ioloop
-from tornado import gen
 from tornado.testing import AsyncTestCase, gen_test
 
 from jaeger_client import senders
@@ -55,14 +54,14 @@ def test_base_sender_set_process_instantiate_jaeger_process():
 def test_base_sender_spanless_flush_is_noop():
     sender = senders.Sender()
     flushed = sender.flush().result()
-    assert flushed is None
+    assert flushed == 0
 
-    
+
 def test_base_sender_processless_flush_is_noop():
     sender = senders.Sender()
     sender.spans.append('foo')
     flushed = sender.flush().result()
-    assert flushed is None
+    assert flushed == 0
 
 
 class CustomException(Exception):

--- a/tests/test_senders.py
+++ b/tests/test_senders.py
@@ -35,8 +35,8 @@ def test_base_sender_create_io_loop_if_not_provided():
 
     sender = senders.Sender()
 
-    assert sender.io_loop is not None
-    assert isinstance(sender.io_loop, ioloop.IOLoop)
+    assert sender._io_loop is not None
+    assert isinstance(sender._io_loop, ioloop.IOLoop)
 
 
 def test_base_sender_send_not_implemented():
@@ -111,7 +111,7 @@ class SenderFlushTest(AsyncTestCase):
 
             sender.spans = [self.span()]
 
-            sender.agent.emitBatch = mock.MagicMock(side_effect=exception(value))
+            sender._agent.emitBatch = mock.MagicMock(side_effect=exception(value))
             assert sender.span_count == 1
 
             try:
@@ -128,28 +128,28 @@ def test_udp_sender_instantiate_thrift_agent():
 
     sender = senders.UDPSender(host='mock', port=4242)
 
-    assert sender.agent is not None
-    assert isinstance(sender.agent, Agent.Client)
+    assert sender._agent is not None
+    assert isinstance(sender._agent, Agent.Client)
 
 
 def test_udp_sender_intantiate_local_agent_channel():
 
     sender = senders.UDPSender(host='mock', port=4242)
 
-    assert sender.channel is not None
-    assert sender.channel.io_loop == sender.io_loop
-    assert isinstance(sender.channel, LocalAgentSender)
+    assert sender._channel is not None
+    assert sender._channel.io_loop == sender._io_loop
+    assert isinstance(sender._channel, LocalAgentSender)
 
 
 def test_udp_sender_calls_agent_emitBatch_on_send():
 
     test_data = {'foo': 'bar'}
     sender = senders.UDPSender(host='mock', port=4242)
-    sender.agent = mock.Mock()
+    sender._agent = mock.Mock()
 
     sender.send(test_data)
 
-    sender.agent.emitBatch.assert_called_once_with(test_data)
+    sender._agent.emitBatch.assert_called_once_with(test_data)
 
 
 def test_udp_sender_implements_thrift_protocol_factory():


### PR DESCRIPTION
Continuing on with the adoption of Sender from https://github.com/jaegertracing/jaeger-client-python/pull/186 and addresses requested changes.

~~This addition still has Reporter manage the consume_queue background callback as it possesses the ErrorReporter and ReporterMetrics attributes (https://github.com/jaegertracing/jaeger-client-python/pull/186#pullrequestreview-144048686).  I plan on moving that functionality to Sender while incorporating appropriate UDP batching in a subsequent PR before adding an HTTPSender.~~

~~edit:  Given https://github.com/jaegertracing/jaeger-client-python/pull/208#issuecomment-416274013 I will add UDP batching to this PR with the expectation that the Reporter span queue management is to roughly stay as is functionally.~~

~~edit 2: UDP batching has been added.~~ https://github.com/jaegertracing/jaeger-client-python/pull/208#issuecomment-430298109  -- Just addressing breaking changes and will introduce UDP batching in another PR.