### PR TITLE
Mark reporter_queue_size Config option as valid

### DIFF
--- a/jaeger_client/config.py
+++ b/jaeger_client/config.py
@@ -116,6 +116,7 @@ class Config(object):
                         'tags',
                         'enabled',
                         'reporter_batch_size',
+                        'reporter_queue_size',
                         'propagation',
                         'max_tag_value_length',
                         'reporter_flush_interval',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -131,6 +131,10 @@ class ConfigTests(unittest.TestCase):
         with self.assertRaises(Exception):
             _ = Config({"unexpected":"value"}, validate=True)
 
+    def test_reporter_queue_size_valid(self):
+        config = Config({"reporter_queue_size": 100}, service_name='x', validate=True)
+        assert config.reporter_queue_size == 100
+
     def test_missing_service_name(self):
         with self.assertRaises(ValueError):
             _ = Config({})


### PR DESCRIPTION
If you add reporter_queue_size as an option in a jaeger_client.Config,
it currently raises an error, even if it's a valid option if
validate=True.