### PR TITLE
Preserve datatype of tag values

### DIFF
--- a/jaeger_client/span.py
+++ b/jaeger_client/span.py
@@ -81,11 +81,10 @@ class Span(opentracing.Span):
             if key == ext_tags.SAMPLING_PRIORITY and not self._set_sampling_priority(value):
                 return self
             if self.is_sampled():
-                tag = thrift.make_string_tag(
+                tag = thrift.make_tag(
                     key=key,
                     value=value,
-                    max_length=self.tracer.max_tag_value_length,
-                )
+                    max_length=self.tracer.max_tag_value_length, )
                 self.tags.append(tag)
         return self
 

--- a/jaeger_client/thrift.py
+++ b/jaeger_client/thrift.py
@@ -47,7 +47,31 @@ def _to_string(s):
         return str(e)
 
 
-def make_string_tag(key, value, max_length):
+def make_tag(key, value, max_length):
+    if type(value).__name__ == 'bool':  # isinstance doesnt work on booleans
+        return _make_bool_tag(
+            key=key,
+            value=value
+        )
+    elif isinstance(value, int):
+        return _make_long_tag(
+            key=key,
+            value=value
+        )
+    elif isinstance(value, float):
+        return _make_double_tag(
+            key=key,
+            value=value
+        )
+    else:
+        return _make_string_tag(
+            key=key,
+            value=value,
+            max_length=max_length
+        )
+
+
+def _make_string_tag(key, value, max_length):
     key = _to_string(key)
     value = _to_string(value)
     if len(value) > max_length:
@@ -56,6 +80,33 @@ def make_string_tag(key, value, max_length):
         key=key,
         vStr=value,
         vType=ttypes.TagType.STRING,
+    )
+
+
+def _make_long_tag(key, value):
+    key = _to_string(key)
+    return ttypes.Tag(
+        key=key,
+        vLong=value,
+        vType=ttypes.TagType.LONG
+    )
+
+
+def _make_double_tag(key, value):
+    key = _to_string(key)
+    return ttypes.Tag(
+        key=key,
+        vDouble=value,
+        vType=ttypes.TagType.DOUBLE
+    )
+
+
+def _make_bool_tag(key, value):
+    key = _to_string(key)
+    return ttypes.Tag(
+        key=key,
+        vBool=value,
+        vType=ttypes.TagType.BOOL
     )
 
 
@@ -72,7 +123,7 @@ def timestamp_micros(ts):
 def make_tags(tags, max_length):
     # TODO extend to support non-string tag values
     return [
-        make_string_tag(key=k, value=v, max_length=max_length)
+        make_tag(key=k, value=v, max_length=max_length)
         for k, v in six.iteritems(tags or {})
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -54,9 +54,9 @@ setup(
             'mock==1.0.1',
             'pycurl>=7.43,<8',
             'pytest>=3.6.0',
-            'pytest-cov',
+            'pytest-cov==2.5.1',
             'coverage<4.4',  # can remove after https://bitbucket.org/ned/coveragepy/issues/581/44b1-44-breaking-in-ci
-            'pytest-timeout',
+            'pytest-timeout==1.3.1',
             'pytest-tornado',
             'pytest-benchmark[histogram]>=3.0.0rc1',
             'pytest-localserver',
@@ -65,7 +65,7 @@ setup(
             'codecov',
             'tchannel>=0.27', # This is only used in python 2
             'opentracing_instrumentation>=2,<3',
-            'prometheus_client',
+            'prometheus_client==0.3.1',
         ]
     },
 )

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -228,3 +228,17 @@ def test_span_tag_value_max_length(tracer):
     tag_n = len(span.tags) - 1
     assert span.tags[tag_n].key == 'x'
     assert span.tags[tag_n].vStr == 'x' * 42
+
+def test_span_tag_bool(tracer):
+    span = tracer.start_span(operation_name='y')
+    span.set_tag('y', True)
+    tag_n = len(span.tags) - 1
+    assert span.tags[tag_n].key == 'y'
+    assert span.tags[tag_n].vBool is True
+
+def test_span_tag_long(tracer):
+    span = tracer.start_span(operation_name='z')
+    span.set_tag('z', 200)
+    tag_n = len(span.tags) - 1
+    assert span.tags[tag_n].key == 'z'
+    assert span.tags[tag_n].vLong == 200

--- a/tests/test_thrift.py
+++ b/tests/test_thrift.py
@@ -92,9 +92,24 @@ def test_large_ids(tracer):
 
 
 def test_large_tags():
-    tag = thrift.make_string_tag('x', 'y' * 300, max_length=256)
+    tag = thrift.make_tag('x', 'y' * 300, max_length=256)
     assert len(tag.vStr) <= 256
 
+def test_bool_tags():
+    tag = thrift.make_tag('booltag', True, max_length=256)
+    assert tag.vBool is True
+
+def test_bool_tags_false():
+    tag = thrift.make_tag('booltag', False, max_length=256)
+    assert tag.vBool is False
+
+def test_long_tags():
+    tag = thrift.make_tag('longtag', 404, max_length=256)
+    assert tag.vLong == 404
+
+def test_double_tags():
+    tag = thrift.make_tag('doubletag', 12.1, max_length=256)
+    assert tag.vDouble == 12.1
 
 def test_parse_sampling_strategy():
     # probabilistic

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -26,10 +26,13 @@ from jaeger_client import ConstSampler, SpanContext, Tracer
 from jaeger_client import constants as c
 
 
-def find_tag(span, key):
+def find_tag(span, key, tag_type='str'):
     for tag in span.tags:
         if tag.key == key:
-            return tag.vStr
+            if tag_type == 'str':
+                return tag.vStr
+            elif tag_type == 'bool':
+                return tag.vBool
     return None
 
 
@@ -209,7 +212,7 @@ def test_tracer_tags_no_hostname():
 @pytest.mark.parametrize('span_type,expected_tags', [
     ('root', {
         'sampler.type': 'const',
-        'sampler.param': 'True',
+        'sampler.param': True,
     }),
     ('child', {
         'sampler.type': None,
@@ -237,7 +240,7 @@ def test_tracer_tags_on_root_span(span_type, expected_tags):
                 tags={ext_tags.SPAN_KIND: ext_tags.SPAN_KIND_RPC_SERVER}
             )
         for key, value in six.iteritems(expected_tags):
-            found_tag = find_tag(span, key)
+            found_tag = find_tag(span, key, type(value).__name__)
             if value is None:
                 assert found_tag is None, 'test (%s)' % span_type
                 continue


### PR DESCRIPTION
This PR implements type checking on the `set_tag` so that kv pairs where the value is not a string gets stored using the correct thrift plumbing. It implements support for booleans, integers (long), doubles in addition to the existing string type, which is also the fallback type.

Here's an example of using it:
![screenshot from 2018-09-29 22-02-28](https://user-images.githubusercontent.com/1747120/46250087-d4f4f680-c433-11e8-9e95-cb83d6244837.png)

Fixes https://github.com/jaegertracing/jaeger-client-python/issues/212