### PR TITLE
Fix handling of missing headers in the b3 codec

### DIFF
--- a/jaeger_client/codecs.py
+++ b/jaeger_client/codecs.py
@@ -295,7 +295,6 @@ class B3Codec(Codec):
         elif span_context.flags & SAMPLED_FLAG == SAMPLED_FLAG:
             carrier[self.sampled_header] = '1'
 
-
     @staticmethod
     def _get_header_value_hex(carrier, header_lc_to_header_orig, header_lc):
         header = header_lc_to_header_orig.get(header_lc)

--- a/jaeger_client/codecs.py
+++ b/jaeger_client/codecs.py
@@ -295,15 +295,26 @@ class B3Codec(Codec):
         elif span_context.flags & SAMPLED_FLAG == SAMPLED_FLAG:
             carrier[self.sampled_header] = '1'
 
+
+    @staticmethod
+    def _get_header_value_hex(carrier, header_lc_to_header_orig, header_lc):
+        header = header_lc_to_header_orig.get(header_lc)
+        if header is None:
+            return None
+        header_value = carrier.get(header)
+        if header_value is not None:
+            header_value = header_to_hex(header_value)
+        return header_value
+
     def extract(self, carrier):
         if not isinstance(carrier, dict):
             raise InvalidCarrierException('carrier not a dictionary')
         lowercase_keys = dict([(k.lower(), k) for k in carrier])
-        trace_id = header_to_hex(carrier.get(lowercase_keys.get(self._trace_header_lc)))
-        span_id = header_to_hex(carrier.get(lowercase_keys.get(self._span_header_lc)))
-        parent_id = carrier.get(lowercase_keys.get(self._parent_span_header_lc))
-        if parent_id:
-            parent_id = header_to_hex(parent_id)
+        trace_id = self._get_header_value_hex(carrier, lowercase_keys, self._trace_header_lc)
+        span_id = self._get_header_value_hex(carrier, lowercase_keys, self._span_header_lc)
+        parent_id = self._get_header_value_hex(carrier, lowercase_keys, self._parent_span_header_lc)
+        if not trace_id or not span_id:
+            return None
         flags = 0x00
         sampled = carrier.get(lowercase_keys.get(self._sampled_header_lc))
         if sampled == '1':

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -339,6 +339,9 @@ class TestCodecs(unittest.TestCase):
         span_context = codec.extract(carrier)
         assert span_context.flags == 0x01
 
+        # validate missing context
+        assert codec.extract({}) is None
+
         # validate invalid hex string
         with self.assertRaises(SpanContextCorruptedException):
             codec.extract({'x-B3-TraceId': 'a2fb4a1d1a96d312z'})

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -339,8 +339,19 @@ class TestCodecs(unittest.TestCase):
         span_context = codec.extract(carrier)
         assert span_context.flags == 0x01
 
+        # validate present debug header with falsy value
+        carrier = {'X-b3-SpanId': 'a2fb4a1d1a96d312', 'X-B3-flags': '0',
+                   'X-B3-traceId': '463ac35c9f6413ad48485a3953bb6124'}
+        span_context = codec.extract(carrier)
+        assert span_context.flags == 0x00
+
         # validate missing context
         assert codec.extract({}) is None
+
+        # validate explicit none in context
+        carrier = {'X-b3-SpanId': None,
+                   'X-B3-traceId': '463ac35c9f6413ad48485a3953bb6124'}
+        assert codec.extract(carrier) is None
 
         # validate invalid hex string
         with self.assertRaises(SpanContextCorruptedException):


### PR DESCRIPTION
The b3 codec uses .get() to extract headers and so does not throw a key
error if headers are missing.  However many of these headers are decoded
via "header_to_hex" which throws an exception on a None value.  Other
codecs handle the missing header case by returning None, update the b3
codec to follow this convention.

Signed-off-by: Caleb Howe <Caleb.S.Howe@gmail.com>