### PR TITLE
Allow setting of the Jaeger Agent Host via environment variable.

### DIFF
--- a/jaeger_client/config.py
+++ b/jaeger_client/config.py
@@ -259,6 +259,11 @@ class Config(object):
         try:
             return self.local_agent_group()['reporting_host']
         except:
+            pass
+
+        if os.getenv('JAEGER_AGENT_HOST') is not None:
+            return os.getenv('JAEGER_AGENT_HOST')
+        else:
             return DEFAULT_REPORTING_HOST
 
     @property

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -87,6 +87,10 @@ class ConfigTests(unittest.TestCase):
         c = Config({'local_agent': {'reporting_host': 'jaeger.local'}}, service_name='x')
         assert c.local_agent_reporting_host == 'jaeger.local'
 
+        os.environ['JAEGER_AGENT_HOST'] = 'jaeger-env.local'
+        c = Config({}, service_name='x')
+        assert c.local_agent_reporting_host == 'jaeger-env.local'
+
     def test_max_tag_value_length(self):
         c = Config({}, service_name='x')
         assert c.max_tag_value_length == constants.MAX_TAG_VALUE_LENGTH


### PR DESCRIPTION
Hi,

On Kubernetes, it would be very convenient if the Jaeger Agent Host can be set via an environment variable. This is also the method described in the Jaeger for Kubernetes docs (https://github.com/jaegertracing/jaeger-kubernetes). Adding this PR will make sure that those Jaeger on Kubernetes docs also work out of the box with projects created using this library. I added a test to make sure it's working as expected.

Please let me know if you need anything changed in here!