### PR TITLE
Remove pytest-tornado from dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,5 +22,3 @@ python_files =
     test_*.py
     *_test.py
     tests.py
-filterwarnings =
-    ignore:RemovedInPytest4Warning

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,3 +22,5 @@ python_files =
     test_*.py
     *_test.py
     tests.py
+filterwarnings =
+    ignore:RemovedInPytest4Warning

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
             'pytest-cov==2.5.1',
             'coverage<4.4',  # can remove after https://bitbucket.org/ned/coveragepy/issues/581/44b1-44-breaking-in-ci
             'pytest-timeout==1.3.1',
-            'pytest-tornado',
             'pytest-benchmark[histogram]>=3.0.0rc1',
             'pytest-localserver',
             'flake8<3',  # see https://github.com/zheller/flake8-quotes/issues/29

--- a/tests/test_crossdock.py
+++ b/tests/test_crossdock.py
@@ -24,143 +24,126 @@ from mock import MagicMock
 if six.PY2:
     from crossdock.server import server
 from tornado.httpclient import HTTPRequest
+import tornado.testing
 from jaeger_client import Tracer, ConstSampler
 from jaeger_client.reporter import InMemoryReporter
 from crossdock.server.endtoend import EndToEndHandler, _determine_host_port, _parse_host_port
 
 tchannel_port = "9999"
-
-
-@pytest.fixture
-def app():
-    """Required by pytest-tornado's http_server fixture"""
-    s = server.Server(int(tchannel_port))
-    s.tchannel.listen()
-    return server.make_app(s, EndToEndHandler())
-
-
-# noinspection PyShadowingNames
-@pytest.yield_fixture
-def tracer():
-    tracer = Tracer(
-        service_name='test-tracer',
-        sampler=ConstSampler(True),
-        reporter=InMemoryReporter(),
-    )
-    try:
-        yield tracer
-    finally:
-        tracer.close()
-
-
 PERMUTATIONS = []
 for s2 in ["HTTP", "TCHANNEL"]:
     for s3 in ["HTTP", "TCHANNEL"]:
         for sampled in [True, False]:
             PERMUTATIONS.append((s2, s3, sampled))
 
+class Test(tornado.testing.AsyncHTTPTestCase):
+    def get_app(self):
+        """Required by tornado's AsyncHTTPTestCase fixture"""
+        s = server.Server(int(tchannel_port))
+        s.tchannel.listen()
+        return server.make_app(s, EndToEndHandler())
 
-# noinspection PyShadowingNames
-@pytest.mark.parametrize('s2_transport,s3_transport,sampled', PERMUTATIONS)
-@pytest.mark.gen_test
-@pytest.mark.skipif(six.PY3, reason="crossdock tests need tchannel that only works with Python 2.7")
-def test_trace_propagation(
-        s2_transport, s3_transport, sampled, tracer,
-        base_url, http_port, http_client):
-
-    # verify that server is ready
-    yield http_client.fetch(
-        request=HTTPRequest(
-            url=base_url,
-            method='HEAD',
+    def get_tracer(self):
+        return Tracer(
+            service_name='test-tracer',
+            sampler=ConstSampler(True),
+            reporter=InMemoryReporter(),
         )
-    )
 
-    level3 = dict()
-    level3["serviceName"] = "python"
-    level3["serverRole"] = "s3"
-    level3["transport"] = s3_transport
-    level3["host"] = "localhost"
-    level3["port"] = str(http_port) if s3_transport == "HTTP" else tchannel_port
+    # noinspection PyShadowingNames
+    @pytest.mark.skipif(six.PY3, reason="crossdock tests need tchannel that only works with Python 2.7")
+    def test_trace_propagation(self):
+        tracer = self.get_tracer()
+        # verify that server is ready
+        self.fetch('/')
 
-    level2 = dict()
-    level2["serviceName"] = "python"
-    level2["serverRole"] = "s2"
-    level2["transport"] = s2_transport
-    level2["host"] = "localhost"
-    level2["port"] = str(http_port) if s2_transport == "HTTP" else tchannel_port
-    level2["downstream"] = level3
+        for (s2_transport, s3_transport, sampled) in PERMUTATIONS:
+            level3 = dict()
+            level3["serviceName"] = "python"
+            level3["serverRole"] = "s3"
+            level3["transport"] = s3_transport
+            level3["host"] = "127.0.0.1"
+            level3["port"] = str(self.get_http_port()) if s3_transport == "HTTP" else tchannel_port
 
-    level1 = dict()
-    level1["baggage"] = "Zoidberg"
-    level1["serverRole"] = "s1"
-    level1["sampled"] = sampled
-    level1["downstream"] = level2
-    body = json.dumps(level1)
+            level2 = dict()
+            level2["serviceName"] = "python"
+            level2["serverRole"] = "s2"
+            level2["transport"] = s2_transport
+            level2["host"] = "127.0.0.1"
+            level2["port"] = str(self.get_http_port()) if s2_transport == "HTTP" else tchannel_port
+            level2["downstream"] = level3
 
-    with mock.patch('opentracing.tracer', tracer):
-        assert opentracing.tracer == tracer # sanity check that patch worked
+            level1 = dict()
+            level1["baggage"] = "Zoidberg"
+            level1["serverRole"] = "s1"
+            level1["sampled"] = sampled
+            level1["downstream"] = level2
+            body = json.dumps(level1)
 
-        req = HTTPRequest(url="%s/start_trace" % base_url, method="POST",
-                          headers={"Content-Type": "application/json"},
-                          body=body,
-                          request_timeout=2)
+            with mock.patch('opentracing.tracer', tracer):
+                assert opentracing.tracer == tracer # sanity check that patch worked
 
-        response = yield http_client.fetch(req)
-        assert response.code == 200
-        tr = server.serializer.traceresponse_from_json(response.body)
-        assert tr is not None
-        assert tr.span is not None
-        assert tr.span.baggage == level1.get("baggage")
-        assert tr.span.sampled == sampled
-        assert tr.span.traceId is not None
-        assert tr.downstream is not None
-        assert tr.downstream.span.baggage == level1.get("baggage")
-        assert tr.downstream.span.sampled == sampled
-        assert tr.downstream.span.traceId == tr.span.traceId
-        assert tr.downstream.downstream is not None
-        assert tr.downstream.downstream.span.baggage == level1.get("baggage")
-        assert tr.downstream.downstream.span.sampled == sampled
-        assert tr.downstream.downstream.span.traceId == tr.span.traceId
+                req = HTTPRequest(url=self.get_url('/start_trace'), method="POST",
+                                  headers={"Content-Type": "application/json"},
+                                  body=body,
+                                  request_timeout=2)
+                response = self.io_loop.run_sync(lambda: self.get_http_client().fetch(req), timeout=15)
+                assert response.code == 200
+                tr = server.serializer.traceresponse_from_json(response.body)
+                assert tr is not None
+                assert tr.span is not None
+                assert tr.span.baggage == level1.get("baggage")
+                assert tr.span.sampled == sampled
+                assert tr.span.traceId is not None
+                assert tr.downstream is not None
+                assert tr.downstream.span.baggage == level1.get("baggage")
+                assert tr.downstream.span.sampled == sampled
+                assert tr.downstream.span.traceId == tr.span.traceId
+                assert tr.downstream.downstream is not None
+                assert tr.downstream.downstream.span.baggage == level1.get("baggage")
+                assert tr.downstream.downstream.span.sampled == sampled
+                assert tr.downstream.downstream.span.traceId == tr.span.traceId
+        tracer.close()
 
 
-# noinspection PyShadowingNames
-@pytest.mark.gen_test
-@pytest.mark.skipif(six.PY3, reason="crossdock tests need tchannel that only works with Python 2.7")
-def test_endtoend_handler(tracer):
-    payload = dict()
-    payload["operation"] = "Zoidberg"
-    payload["count"] = 2
-    payload["tags"] = {"key":"value"}
-    body = json.dumps(payload)
+    # noinspection PyShadowingNames
+    @pytest.mark.skipif(six.PY3, reason="crossdock tests need tchannel that only works with Python 2.7")
+    def test_endtoend_handler(self):
+        tracer = self.get_tracer()
+        payload = dict()
+        payload["operation"] = "Zoidberg"
+        payload["count"] = 2
+        payload["tags"] = {"key":"value"}
+        body = json.dumps(payload)
 
-    h = EndToEndHandler()
-    request = MagicMock(body=body)
-    response_writer = MagicMock()
-    response_writer.finish.return_value = None
+        h = EndToEndHandler()
+        request = MagicMock(body=body)
+        response_writer = MagicMock()
+        response_writer.finish.return_value = None
 
-    h.tracers = {"remote": tracer}
-    h.generate_traces(request, response_writer)
+        h.tracers = {"remote": tracer}
+        h.generate_traces(request, response_writer)
 
-    spans = tracer.reporter.get_spans()
-    assert len(spans) == 2
+        spans = tracer.reporter.get_spans()
+        assert len(spans) == 2
+        tracer.close()
 
 def test_determine_host_port():
     original_value = os.environ.get('AGENT_HOST_PORT', None)
-    os.environ['AGENT_HOST_PORT'] = 'localhost:1234'
+    os.environ['AGENT_HOST_PORT'] = '127.0.0.1:1234'
     host, port = _determine_host_port()
 
     # Before any assertions, restore original environment variable.
     if original_value:
         os.environ['AGENT_HOST_PORT'] = original_value
 
-    assert host == 'localhost'
+    assert host == '127.0.0.1'
     assert port == 1234
 
 def test_parse_host_port():
     test_cases = [
-        [('', 'localhost', 5678), ('localhost', 5678)],
-        [('test:1234', 'localhost', 5678), ('test', 1234)],
+        [('', '127.0.0.1', 5678), ('127.0.0.1', 5678)],
+        [('test:1234', '127.0.0.1', 5678), ('test', 1234)],
     ]
     for test_case in test_cases:
         args, result = test_case


### PR DESCRIPTION
pytest-tornado is no longer maintained. A pull request was submitted months ago for an error we have seen repeatedly in our unit tests (https://github.com/eugeniy/pytest-tornado/pull/38). Nonetheless, the pull request has not been merged. We should just use regular tornado testing utilities to avoid this unmaintained package.