### PR TITLE
 Add 128bit trace_id support

### DIFF
--- a/jaeger_client/config.py
+++ b/jaeger_client/config.py
@@ -122,6 +122,7 @@ class Config(object):
                         'reporter_flush_interval',
                         'sampling_refresh_interval',
                         'trace_id_header',
+                        'generate_128bit_trace_id',
                         'baggage_header_prefix',
                         'service_name',
                         'throttler']
@@ -165,6 +166,16 @@ class Config(object):
         :return: Returns the name of the HTTP header used to encode trace ID
         """
         return self.config.get('trace_id_header', TRACE_ID_HEADER)
+
+    @property
+    def generate_128bit_trace_id(self):
+        """
+        :return: Returns boolean value to indicate if 128bit trace_id
+        generation is enabled
+        """
+        if 'generate_128bit_trace_id' in self.config:
+            return get_boolean(self.config['generate_128bit_trace_id'], False)
+        return os.getenv('JAEGER_TRACEID_128BIT') == 'true'
 
     @property
     def baggage_header_prefix(self):
@@ -395,6 +406,7 @@ class Config(object):
             sampler=sampler,
             metrics_factory=self._metrics_factory,
             trace_id_header=self.trace_id_header,
+            generate_128bit_trace_id=self.generate_128bit_trace_id,
             baggage_header_prefix=self.baggage_header_prefix,
             debug_id_header=self.debug_id_header,
             tags=self.tags,

--- a/jaeger_client/constants.py
+++ b/jaeger_client/constants.py
@@ -18,8 +18,14 @@ from . import __version__
 
 import six
 
-# Max number of bits to use when generating random ID
+# DEPRECATED: max number of bits to use when generating random ID
 MAX_ID_BITS = 64
+
+# Max number of bits allowed to use when generating Trace ID
+_max_trace_id_bits = 128
+
+# Max number of bits to use when generating random ID
+_max_id_bits = 64
 
 # How often remotely controlled sampler polls for sampling strategy
 DEFAULT_SAMPLING_INTERVAL = 60

--- a/jaeger_client/sampler.py
+++ b/jaeger_client/sampler.py
@@ -22,7 +22,7 @@ import six
 from threading import Lock
 from tornado.ioloop import PeriodicCallback
 from .constants import (
-    MAX_ID_BITS,
+    _max_id_bits,
     DEFAULT_SAMPLING_INTERVAL,
     SAMPLER_TYPE_CONST,
     SAMPLER_TYPE_PROBABILISTIC,
@@ -121,7 +121,7 @@ class ProbabilisticSampler(Sampler):
         )
         assert 0.0 <= rate <= 1.0, 'Sampling rate must be between 0.0 and 1.0'
         self.rate = rate
-        self.max_number = 1 << MAX_ID_BITS
+        self.max_number = 1 << _max_id_bits
         self.boundary = rate * self.max_number
 
     def is_sampled(self, trace_id, operation=''):

--- a/jaeger_client/sampler.py
+++ b/jaeger_client/sampler.py
@@ -125,6 +125,7 @@ class ProbabilisticSampler(Sampler):
         self.boundary = rate * self.max_number
 
     def is_sampled(self, trace_id, operation=''):
+        trace_id = trace_id & (self.max_number - 1)
         return trace_id < self.boundary, self._tags
 
     def close(self):

--- a/jaeger_client/thrift.py
+++ b/jaeger_client/thrift.py
@@ -26,6 +26,24 @@ if six.PY3:
     long = int
 
 
+def _id_to_low(big_id):
+    """
+    :param big_id: id in integer
+    :return: Returns the right most 64 bits of big_id
+    """
+    if big_id is not None:
+        return big_id & (_max_unsigned_id - 1)
+
+
+def _id_to_high(big_id):
+    """
+    :param big_id: id in integer
+    :return: Returns the left most 64 bits of big_id
+    """
+    if big_id is not None:
+        return (big_id >> 64) & (_max_unsigned_id - 1)
+
+
 def id_to_int(big_id):
     if big_id is None:
         return None
@@ -150,8 +168,8 @@ def make_jaeger_batch(spans, process):
     for span in spans:
         with span.update_lock:
             jaeger_span = ttypes.Span(
-                traceIdLow=id_to_int(span.trace_id),
-                traceIdHigh=0,
+                traceIdLow=id_to_int(_id_to_low(span.trace_id)),
+                traceIdHigh=id_to_int(_id_to_high(span.trace_id)),
                 spanId=id_to_int(span.span_id),
                 parentSpanId=id_to_int(span.parent_id) or 0,
                 operationName=span.operation_name,

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -29,6 +29,7 @@ from jaeger_client.codecs import (
 )
 from jaeger_client.config import Config
 from jaeger_client.reporter import InMemoryReporter
+from jaeger_client import constants
 from opentracing import Format
 from opentracing.propagation import (
     InvalidCarrierException,
@@ -83,6 +84,8 @@ class TestCodecs(unittest.TestCase):
         tests = [
             [(256, 127, None, 1), '100:7f:0:1'],
             [(256, 127, 256, 0), '100:7f:100:0'],
+            [(0xffffffffffffffffffffffffffffffff, 127, 256, 0),
+             'ffffffffffffffffffffffffffffffff:7f:100:0'],
         ]
         for test in tests:
             ctx = test[0]
@@ -450,6 +453,52 @@ def test_round_trip(tracer, fmt, carrier):
         context = tracer2.extract(fmt, carrier)
         span2 = tracer2.start_span('test-%s' % fmt, child_of=context)
         assert span.trace_id == span2.trace_id
+
+
+def _text_codec_to_trace_id_string(carrier):
+    return carrier[constants.TRACE_ID_HEADER].split(':')[0]
+
+
+def _zipkin_codec_to_trace_id_string(carrier):
+    return '{:x}'.format(carrier['trace_id'])
+
+
+@pytest.mark.parametrize('fmt,carrier,get_trace_id', [
+    (Format.TEXT_MAP, {}, _text_codec_to_trace_id_string),
+    (Format.HTTP_HEADERS, {}, _text_codec_to_trace_id_string),
+    (ZipkinSpanFormat, {}, _zipkin_codec_to_trace_id_string),
+])
+def test_inject_with_128bit_trace_id(tracer, fmt, carrier, get_trace_id):
+    tracer_128bit = Tracer(
+        service_name='test',
+        reporter=InMemoryReporter(),
+        sampler=ConstSampler(True),
+        generate_128bit_trace_id=True)
+
+    for tracer in [tracer, tracer_128bit]:
+        length = tracer.max_trace_id_bits / 4
+        trace_id = (1 << 64) - 1 if length == 16 else (1 << 128) - 1
+        ctx = SpanContext(trace_id=trace_id, span_id=127, parent_id=None,
+                          flags=1)
+        span = Span(ctx, operation_name='test-%s' % fmt, tracer=None, start_time=1)
+        tracer.inject(span, fmt, carrier)
+        assert len(get_trace_id(carrier)) == length
+
+        # test if the trace_id arrived on wire remains same even if
+        # the tracer is configured for 64bit ids or 128bit ids
+        ctx = SpanContext(trace_id=(1 << 128) - 1, span_id=127, parent_id=None,
+                          flags=0)
+        span = tracer.start_span('test-%s' % fmt, child_of=ctx)
+        carrier = dict()
+        tracer.inject(span, fmt, carrier)
+        assert len(get_trace_id(carrier)) == 32
+
+        ctx = SpanContext(trace_id=(1 << 64) - 1, span_id=127, parent_id=None,
+                          flags=0)
+        span = tracer.start_span('test-%s' % fmt, child_of=ctx)
+        carrier = dict()
+        tracer.inject(span, fmt, carrier)
+        assert len(get_trace_id(carrier)) == 16
 
 
 def test_debug_id():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -156,3 +156,20 @@ class ConfigTests(unittest.TestCase):
     def test_default_local_agent_reporting_port(self):
         c = Config({}, service_name='x')
         assert c.local_agent_reporting_port == 6831
+
+    def test_generate_128bit_trace_id(self):
+        c = Config({}, service_name='x')
+        assert c.generate_128bit_trace_id is False
+
+        c = Config({'generate_128bit_trace_id': True}, service_name='x')
+        assert c.generate_128bit_trace_id is True
+
+        os.environ['JAEGER_TRACEID_128BIT'] = 'true'
+        c = Config({'generate_128bit_trace_id': False}, service_name='x')
+        assert c.generate_128bit_trace_id is False
+
+        c = Config({}, service_name='x')
+        assert c.generate_128bit_trace_id is True
+
+        os.environ.pop('JAEGER_TRACEID_128BIT')
+        assert os.getenv('JAEGER_TRACEID_128BIT', None) is None

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -195,7 +195,7 @@ def test_guaranteed_throughput_probabilistic_sampler():
     sampled, tags = sampler.is_sampled(MAX_INT - 10)
     assert sampled
     assert tags == get_tags('probabilistic', 0.51)
-    sampled, tags = sampler.is_sampled(MAX_INT + (MAX_INT / 4))
+    sampled, tags = sampler.is_sampled(int(MAX_INT + (MAX_INT / 4)))
     assert sampled
     assert tags == get_tags('lowerbound', 0.51)
 
@@ -234,7 +234,7 @@ def test_adaptive_sampler():
         # Move time forward by a second to guarantee the rate limiter has enough credits
         mock_time.side_effect = lambda: ts + 1
 
-        sampled, tags = sampler.is_sampled(MAX_INT + (MAX_INT / 4), 'new_op')
+        sampled, tags = sampler.is_sampled(int(MAX_INT + (MAX_INT / 4)), 'new_op')
         assert sampled
         assert tags == get_tags('lowerbound', 0.51)
 
@@ -243,7 +243,7 @@ def test_adaptive_sampler():
     sampled, tags = sampler.is_sampled(MAX_INT - 10, 'new_op_2')
     assert sampled
     assert tags == get_tags('probabilistic', 0.51)
-    sampled, _ = sampler.is_sampled(MAX_INT + (MAX_INT / 4), 'new_op_2')
+    sampled, _ = sampler.is_sampled(int(MAX_INT + (MAX_INT / 4)), 'new_op_2')
     assert not sampled
     assert '%s' % sampler == 'AdaptiveSampler(0.510000, 3.000000, 2)'
 

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -305,3 +305,22 @@ def test_tracer_throttler():
     debug_span_context = SpanContext.with_debug_id('debug-id')
     span = tracer.start_span('test-operation', child_of=debug_span_context)
     assert not span.is_debug()
+
+
+def test_tracer_128bit_trace_id():
+    reporter = mock.MagicMock()
+    sampler = mock.MagicMock()
+    tracer = Tracer(
+        service_name='x',
+        reporter=reporter,
+        sampler=sampler,
+    )
+    assert tracer.max_trace_id_bits == c._max_id_bits
+
+    tracer = Tracer(
+        service_name='x',
+        reporter=reporter,
+        sampler=sampler,
+        generate_128bit_trace_id=True,
+    )
+    assert tracer.max_trace_id_bits == c._max_trace_id_bits


### PR DESCRIPTION
- Creates a new property in Config `generate_128bit_trace_id` if set
  to `True` then 128bit trace_ids are generated
  - Adds support for environment variable `JAEGER_TRACEID_128BIT`. If
  the value is 'true' then 128bit trace_ids are generated
- Tracer takes variable `generate_128bit_trace_id`, if the value is `True`
  then `max_trace_id_bits` is set to `constants._max_trace_id_bits`
  - Adds new function `_random_id(bitsize)`
  - Deprecate `random_id()` in favor of `_random_id(bitsize)`
- Deprecate `MAX_ID_BITS` in favor of `_max_trace_id_bits` and `_max_id_bits`
- Set low and high bits of traceId correctly
  - Uses `_id_to_high()` and `_id_to_low()` to do that

Fixes #228 
ref: https://github.com/jaegertracing/jaeger/issues/858