### PR TITLE
Unpin flake8 to allow v3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ clean:
 
 .PHONY: lint
 lint:
-	$(flake8) $(projects) tests
+	$(flake8) $(projects)
 	./scripts/check-license.sh
 
 .PHONY: shell

--- a/crossdock/server/serializer.py
+++ b/crossdock/server/serializer.py
@@ -76,7 +76,7 @@ def traceresponse_from_struct(json_obj):
 def traceresponse_from_json(json_str):
     try:
         return traceresponse_from_struct(json.loads(json_str))
-    except:
+    except:  # noqa: E722
         logging.exception('Failed to parse JSON')
         raise
 

--- a/jaeger_client/config.py
+++ b/jaeger_client/config.py
@@ -230,7 +230,7 @@ class Config(object):
             return get_boolean(self.local_agent_group().get('enabled',
                                LOCAL_AGENT_DEFAULT_ENABLED),
                                LOCAL_AGENT_DEFAULT_ENABLED)
-        except:
+        except:  # noqa: E722
             return LOCAL_AGENT_DEFAULT_ENABLED
 
     @property
@@ -238,7 +238,7 @@ class Config(object):
         # noinspection PyBroadException
         try:
             return int(self.local_agent_group()['sampling_port'])
-        except:
+        except:  # noqa: E722
             return DEFAULT_SAMPLING_PORT
 
     @property
@@ -246,12 +246,12 @@ class Config(object):
         # noinspection PyBroadException
         try:
             return int(self.local_agent_group()['reporting_port'])
-        except:
+        except:  # noqa: E722
             pass
 
         try:
             return int(os.getenv('JAEGER_AGENT_PORT'))
-        except:
+        except:  # noqa: E722
             return DEFAULT_REPORTING_PORT
 
     @property
@@ -259,7 +259,7 @@ class Config(object):
         # noinspection PyBroadException
         try:
             return self.local_agent_group()['reporting_host']
-        except:
+        except:  # noqa: E722
             pass
 
         if os.getenv('JAEGER_AGENT_HOST') is not None:
@@ -304,7 +304,7 @@ class Config(object):
         # noinspection PyBroadException
         try:
             return int(throttler_config['port'])
-        except:
+        except:  # noqa: E722
             return DEFAULT_THROTTLER_PORT
 
     @property
@@ -315,7 +315,7 @@ class Config(object):
         # noinspection PyBroadException
         try:
             return int(throttler_config['refresh_interval'])
-        except:
+        except:  # noqa: E722
             return DEFAULT_THROTTLER_REFRESH_INTERVAL
 
     @staticmethod

--- a/jaeger_client/sampler.py
+++ b/jaeger_client/sampler.py
@@ -71,8 +71,9 @@ class Sampler(object):
         raise NotImplementedError()
 
     def __eq__(self, other):
-        return (isinstance(other, self.__class__) and
-                self.__dict__ == other.__dict__)
+        return (
+            isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+        )
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
             'pytest-tornado',
             'pytest-benchmark[histogram]>=3.0.0rc1',
             'pytest-localserver',
-            'flake8<3',  # see https://github.com/zheller/flake8-quotes/issues/29
+            'flake8',
             'flake8-quotes',
             'codecov',
             'tchannel>=0.27', # This is only used in python 2

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,8 @@ setup(
             'coverage<4.4',  # can remove after https://bitbucket.org/ned/coveragepy/issues/581/44b1-44-breaking-in-ci
             'pytest-timeout==1.3.1',
             'pytest-tornado',
-            'pytest-benchmark[histogram]>=3.0.0rc1',
+            # pin <3.2 as otherwise it requires pytest>=3.8
+            'pytest-benchmark[histogram]>=3.0.0rc1,<3.2',
             'pytest-localserver',
             'flake8',
             'flake8-quotes',


### PR DESCRIPTION
and fix a few minor breaks

also remove `tests` from lint, because they were skipped in flake8 config anyway