### PR TITLE
Support Tornado 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,10 @@ dist: trusty
 
 language: python
 
-matrix:
-  include:
-  - python: '2.7'
-    env: COVER=1
-  - python: '2.7'
-    env: CROSSDOCK=1
-  - python: '3.5'
-  - python: '3.6'
+python:
+  - "2.7"
+  - "3.5"
+  - "3.6"
 
 services:
   - docker
@@ -24,9 +20,21 @@ env:
     - secure: "V2CBqCBxMOv9H3v/DcDVPABcxktssVaupbQh7qU2rLFWv5SmJKBN+0ZixmPFQ5ivwNcs93HM+Qck6plY+VGxIFMppvkUveJqKoXnLvk/fdrOyeneQubYXxR3Z2FF5Klml8Jdhi6L6BbYNyeCSMBUljCHj5cnEVA9Z+z8jUxywxk1KjtEDIulzb79TaZaA6pQVA9NRzxnGWqNnlV+9D35Ik0JXMRVMumSPwux6yJvoCQG3J6oJ/drvsdD890xnofuDc71yZTNXKQABqkRheTvDFaQdP8TDSyy71q9A74L+PRpwxP+cF77w8EzXRcFGKrl0xJZMQDpr8Wz8JUL36ft9xSoI6EJChyipIl2G2K1wpx6N8/9YxTkVIDiSxt5CvqJj2gt37GjR8W6qU3cBnwrpFaC+RJtiou/YJstSmwC/hsskTSKy3wDaa7G13pMhXEAhvfplDOchOuNG6ElLkatJ1RxPTdKtZc1YGg4OTcXFg+BqRIEZ57RJ3qTsxpWjZYmo2RwklAL6CfaFBUPGZiNrE4MGhO4/cXbqqaXG+X2sercW658+o7M7RE/BwC4+e5mDGOLGiry5Qy7+9bVJqJKTN8UVmhCJ23MNasVqAcQvzsGp1nZYQYFzcSfGRzqrqM2zIY6sjj5rfDGyYd8ifQFEi6fdWgMqF17PgUvKUHd5dM="
     # DOCKER_PASS
     - secure: "xxoMQo7hF+yr8SyITXonPQahEDcy5Y+uyX4kiVQxtlRIN/Nd1vL64PIocB/M4k9MhSMmz15fFjTtHuzk/tVKpHpgX9SFVCRRAt5qbzekm9NOce25BqJm33zgEKO979sNtn5Aen8ocU5uIar9IKhzV/SaEXPDqNmCGlnF/xAbvKjtTq+PjLy4xj6UKHTvSfYQFsOBgVzmZk759XVAiODN2szIzzXTNMfxOK6FG7w7O2U9VZ7lsvqC7NymXSocp4iF4kOlvAq13sFGYYMJ+1yReODAGNsUZv0TPgPT5NSxPA5OxjVNlPnlmvD6IjZvzpkciPyjsUTV8OIiuyE8GdUKc1FHKvUavN16ac7vC2dAv1VYNFvlr61RIpUAMNk+7k9fX6M5mHBzhnfNSjF2MmKyVDv4PqgLAQOtk9Vbhd8EdZS+/3MRg8DZDWQE8h0rPJQTPWDTMQ4q4yQcpygBnICB0gACIlTFSevnvsTQGUQfR/0GPB8AGsEHTSw7FUQI7dD1JYteRlgk9vNeYpeYrtgom5v9KSeaio1gTB7OlTd3car2iTYSPUgYpXLLY4vV/HEVW+FUWtCkgojWACUmFschNGPxV+nkjjlgj+Nonnz4XK5Y4l4W8Y6N7fTpxEIB9O+5e+Xnf6RhvoWvw/uMbagvK2U+sqFcV0tj8KyfWqtAm3s="
+  matrix:
+    - TORNADO=">=4,<5"
+    - TORNADO=">=5,<6"
+    - COVER=1 CROSSDOCK=1
+
+matrix:
+  exclude:
+  - python: "3.5"
+    env: COVER=1 CROSSDOCK=1
+  - python: "3.6"
+    env: COVER=1 CROSSDOCK=1
 
 install:
   - make bootstrap
+  - pip install -q "tornado$TORNADO"
   - if [ "$CROSSDOCK" == "1" ]; then bash ./scripts/install-crossdock-deps.sh ; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,6 @@ dist: trusty
 
 language: python
 
-python:
-  - "2.7"
-  - "3.5"
-  - "3.6"
-
 services:
   - docker
 
@@ -20,26 +15,26 @@ env:
     - secure: "V2CBqCBxMOv9H3v/DcDVPABcxktssVaupbQh7qU2rLFWv5SmJKBN+0ZixmPFQ5ivwNcs93HM+Qck6plY+VGxIFMppvkUveJqKoXnLvk/fdrOyeneQubYXxR3Z2FF5Klml8Jdhi6L6BbYNyeCSMBUljCHj5cnEVA9Z+z8jUxywxk1KjtEDIulzb79TaZaA6pQVA9NRzxnGWqNnlV+9D35Ik0JXMRVMumSPwux6yJvoCQG3J6oJ/drvsdD890xnofuDc71yZTNXKQABqkRheTvDFaQdP8TDSyy71q9A74L+PRpwxP+cF77w8EzXRcFGKrl0xJZMQDpr8Wz8JUL36ft9xSoI6EJChyipIl2G2K1wpx6N8/9YxTkVIDiSxt5CvqJj2gt37GjR8W6qU3cBnwrpFaC+RJtiou/YJstSmwC/hsskTSKy3wDaa7G13pMhXEAhvfplDOchOuNG6ElLkatJ1RxPTdKtZc1YGg4OTcXFg+BqRIEZ57RJ3qTsxpWjZYmo2RwklAL6CfaFBUPGZiNrE4MGhO4/cXbqqaXG+X2sercW658+o7M7RE/BwC4+e5mDGOLGiry5Qy7+9bVJqJKTN8UVmhCJ23MNasVqAcQvzsGp1nZYQYFzcSfGRzqrqM2zIY6sjj5rfDGyYd8ifQFEi6fdWgMqF17PgUvKUHd5dM="
     # DOCKER_PASS
     - secure: "xxoMQo7hF+yr8SyITXonPQahEDcy5Y+uyX4kiVQxtlRIN/Nd1vL64PIocB/M4k9MhSMmz15fFjTtHuzk/tVKpHpgX9SFVCRRAt5qbzekm9NOce25BqJm33zgEKO979sNtn5Aen8ocU5uIar9IKhzV/SaEXPDqNmCGlnF/xAbvKjtTq+PjLy4xj6UKHTvSfYQFsOBgVzmZk759XVAiODN2szIzzXTNMfxOK6FG7w7O2U9VZ7lsvqC7NymXSocp4iF4kOlvAq13sFGYYMJ+1yReODAGNsUZv0TPgPT5NSxPA5OxjVNlPnlmvD6IjZvzpkciPyjsUTV8OIiuyE8GdUKc1FHKvUavN16ac7vC2dAv1VYNFvlr61RIpUAMNk+7k9fX6M5mHBzhnfNSjF2MmKyVDv4PqgLAQOtk9Vbhd8EdZS+/3MRg8DZDWQE8h0rPJQTPWDTMQ4q4yQcpygBnICB0gACIlTFSevnvsTQGUQfR/0GPB8AGsEHTSw7FUQI7dD1JYteRlgk9vNeYpeYrtgom5v9KSeaio1gTB7OlTd3car2iTYSPUgYpXLLY4vV/HEVW+FUWtCkgojWACUmFschNGPxV+nkjjlgj+Nonnz4XK5Y4l4W8Y6N7fTpxEIB9O+5e+Xnf6RhvoWvw/uMbagvK2U+sqFcV0tj8KyfWqtAm3s="
-  matrix:
-    - TORNADO=">=4,<5"
-    - TORNADO=">=5,<6"
-    - COVER=1
-    - CROSSDOCK=1
 
 matrix:
-  exclude:
+  include:
+  - python: "2.7"
+    env: TORNADO=">=4,<5" CROSSDOCK=1
+  - python: "2.7"
+    env: TORNADO=">=4,<5"
+  - python: "2.7"
+    env: TORNADO=">=5,<6" COVER=1
   - python: "3.5"
-    env: COVER=1
+    env: TORNADO=">=4,<5"
   - python: "3.5"
-    env: CROSSDOCK=1
+    env: TORNADO=">=5,<6"
   - python: "3.6"
-    env: COVER=1
+    env: TORNADO=">=4,<5"
   - python: "3.6"
-    env: CROSSDOCK=1
+    env: TORNADO=">=5,<6"
 
 install:
   - make bootstrap
-  - pip install -q "tornado$TORNADO"
   - if [ "$CROSSDOCK" == "1" ]; then bash ./scripts/install-crossdock-deps.sh ; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,19 @@ env:
   matrix:
     - TORNADO=">=4,<5"
     - TORNADO=">=5,<6"
-    - COVER=1 CROSSDOCK=1
+    - COVER=1
+    - CROSSDOCK=1
 
 matrix:
   exclude:
   - python: "3.5"
-    env: COVER=1 CROSSDOCK=1
+    env: COVER=1
+  - python: "3.5"
+    env: CROSSDOCK=1
   - python: "3.6"
-    env: COVER=1 CROSSDOCK=1
+    env: COVER=1
+  - python: "3.6"
+    env: CROSSDOCK=1
 
 install:
   - make bootstrap

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ test_ci: clean test-import test lint
 test-import:
 	virtualenv import-test
 	import-test/bin/pip install -e .
+	pip install "tornado$(TORNADO)"  # Reinstall Tornado version for testing.
 	import-test/bin/python -c "import jaeger_client"
 	rm -rf import-test
 

--- a/crossdock/Dockerfile
+++ b/crossdock/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:2.7
 
+ARG tornado
 ENV APPDIR /usr/src/app/
+ENV TORNADO=$tornado
 RUN mkdir -p ${APPDIR}
 WORKDIR ${APPDIR}
 
@@ -19,6 +21,7 @@ RUN pip install --no-cache-dir -r requirements-dev.txt
 RUN pip install --no-cache-dir -r requirements-tests.txt
 RUN pip install --no-cache-dir -r requirements.txt
 RUN python setup.py install
+RUN pip install --no-cache-dir "tornado${TORNADO}"
 
 COPY crossdock ${APPDIR}/crossdock/
 COPY crossdock/setup_crossdock.py ${APPDIR}

--- a/crossdock/docker-compose.yml
+++ b/crossdock/docker-compose.yml
@@ -46,6 +46,8 @@ services:
     python:
         build:
             context: ../.
+            args:
+              tornado: ${TORNADO}
             dockerfile: crossdock/Dockerfile
         ports:
             - "8080-8082"

--- a/crossdock/server/server.py
+++ b/crossdock/server/server.py
@@ -16,6 +16,7 @@ import logging
 
 import tornado.web
 import opentracing
+from opentracing.scope_managers.tornado import TornadoScopeManager
 import tornado.ioloop
 import tornado.httpclient
 from tornado.web import asynchronous
@@ -42,7 +43,8 @@ DefaultServerPortTChannel = 8082
 tracer = Tracer(
     service_name='python',
     reporter=NullReporter(),
-    sampler=ConstSampler(decision=True))
+    sampler=ConstSampler(decision=True),
+    scope_manager=TornadoScopeManager())
 opentracing.set_global_tracer(tracer)
 
 

--- a/jaeger_client/sampler.py
+++ b/jaeger_client/sampler.py
@@ -417,8 +417,7 @@ class RemoteControlledSampler(Sampler):
         return PeriodicCallback(
             callback=self._poll_sampling_manager,
             # convert interval to milliseconds
-            callback_time=self.sampling_refresh_interval * 1000,
-            io_loop=self.io_loop)
+            callback_time=self.sampling_refresh_interval * 1000)
 
     def _sampling_request_callback(self, future):
         exception = future.exception()

--- a/jaeger_client/thrift_gen/agent/Agent.py
+++ b/jaeger_client/thrift_gen/agent/Agent.py
@@ -49,7 +49,7 @@ class Client(Iface):
     self._reqs = {}
     self._transport.io_loop.spawn_callback(self._start_receiving)
 
-  @gen.engine
+  @gen.coroutine
   def _start_receiving(self):
     while True:
       try:

--- a/jaeger_client/thrift_gen/jaeger/Collector.py
+++ b/jaeger_client/thrift_gen/jaeger/Collector.py
@@ -42,7 +42,7 @@ class Client(Iface):
     self._reqs = {}
     self._transport.io_loop.spawn_callback(self._start_receiving)
 
-  @gen.engine
+  @gen.coroutine
   def _start_receiving(self):
     while True:
       try:

--- a/jaeger_client/thrift_gen/sampling/SamplingManager.py
+++ b/jaeger_client/thrift_gen/sampling/SamplingManager.py
@@ -42,7 +42,7 @@ class Client(Iface):
     self._reqs = {}
     self._transport.io_loop.spawn_callback(self._start_receiving)
 
-  @gen.engine
+  @gen.coroutine
   def _start_receiving(self):
     while True:
       try:

--- a/jaeger_client/thrift_gen/zipkincore/ZipkinCollector.py
+++ b/jaeger_client/thrift_gen/zipkincore/ZipkinCollector.py
@@ -42,7 +42,7 @@ class Client(Iface):
     self._reqs = {}
     self._transport.io_loop.spawn_callback(self._start_receiving)
 
-  @gen.engine
+  @gen.coroutine
   def _start_receiving(self):
     while True:
       try:

--- a/jaeger_client/throttler.py
+++ b/jaeger_client/throttler.py
@@ -115,8 +115,7 @@ class RemoteThrottler(object):
         periodic = PeriodicCallback(
             callback=callback,
             # convert interval to milliseconds
-            callback_time=self.refresh_interval * 1000,
-            io_loop=self.channel.io_loop)
+            callback_time=self.refresh_interval * 1000)
         self._fetch_credits(self._operations())
         with self.lock:
             if not self.running:

--- a/scripts/build-crossdock.sh
+++ b/scripts/build-crossdock.sh
@@ -7,7 +7,8 @@ make crossdock
 export REPO=jaegertracing/xdock-py
 export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
 export TAG=`if [ "$BRANCH" == "master" ]; then echo "latest"; else echo "${BRANCH///}"; fi`
-echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, REPO=$REPO, PR=$PR, BRANCH=$BRANCH, TAG=$TAG"
+export TORNADO=$TORNADO
+echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, REPO=$REPO, PR=$PR, BRANCH=$BRANCH, TAG=$TAG, TORNADO=$TORNADO"
 
 # Only push the docker container to Docker Hub for master branch
 if [[ "$BRANCH" == "master" && "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
@@ -21,7 +22,7 @@ docker login -u $DOCKER_USER -p $DOCKER_PASS
 
 set -x
 
-docker build -f crossdock/Dockerfile -t $REPO:$COMMIT .
+docker build --build-arg tornado=$TORNADO -f crossdock/Dockerfile -t $REPO:$COMMIT .
 
 docker tag $REPO:$COMMIT $REPO:$TAG
 docker tag $REPO:$COMMIT $REPO:travis-$TRAVIS_BUILD_NUMBER

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
             'flake8-quotes',
             'codecov',
             'tchannel>=0.27', # This is only used in python 2
+            'opentracing_instrumentation',
             'prometheus_client==0.3.1',
         ]
     },

--- a/setup.py
+++ b/setup.py
@@ -66,8 +66,8 @@ setup(
             'flake8',
             'flake8-quotes',
             'codecov',
-            'tchannel>=0.27', # This is only used in python 2
-            'opentracing_instrumentation',
+            'tchannel>=0.27',  # This is only used in python 2
+            'opentracing_instrumentation>=3,<4',
             'prometheus_client==0.3.1',
         ]
     },

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     install_requires=[
         'threadloop>=1,<2',
         'thrift',
-        'tornado>=4.3,<5',
+        'tornado>=4.3,<6',
         'opentracing>=2.1,<3.0',
     ],
     # Uncomment below if need to test with unreleased version of opentracing
@@ -67,7 +67,6 @@ setup(
             'flake8-quotes',
             'codecov',
             'tchannel>=0.27', # This is only used in python 2
-            'opentracing_instrumentation>=2,<3',
             'prometheus_client==0.3.1',
         ]
     },

--- a/tests/test_crossdock.py
+++ b/tests/test_crossdock.py
@@ -20,6 +20,7 @@ import json
 import os
 import pytest
 import opentracing
+from opentracing.scope_managers.tornado import TornadoScopeManager
 from mock import MagicMock
 from tornado.httpclient import HTTPRequest
 from jaeger_client import Tracer, ConstSampler
@@ -47,6 +48,7 @@ def tracer():
         service_name='test-tracer',
         sampler=ConstSampler(True),
         reporter=InMemoryReporter(),
+        scope_manager=TornadoScopeManager()
     )
     try:
         yield tracer

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -58,42 +58,6 @@ def test_logging_reporter():
     reporter.close().result()
 
 
-def test_composite_reporter():
-    reporter = jaeger_client.reporter.CompositeReporter(
-        jaeger_client.reporter.NullReporter(),
-        jaeger_client.reporter.LoggingReporter())
-    with mock.patch('jaeger_client.reporter.NullReporter.set_process') \
-            as null_mock:
-        with mock.patch('jaeger_client.reporter.LoggingReporter.set_process') \
-                as log_mock:
-            reporter.set_process('x', {}, 123)
-            null_mock.assert_called_with('x', {}, 123)
-            log_mock.assert_called_with('x', {}, 123)
-    with mock.patch('jaeger_client.reporter.NullReporter.report_span') \
-            as null_mock:
-        with mock.patch('jaeger_client.reporter.LoggingReporter.report_span') \
-                as log_mock:
-            reporter.report_span({})
-            null_mock.assert_called_with({})
-            log_mock.assert_called_with({})
-    with mock.patch('jaeger_client.reporter.NullReporter.close') \
-            as null_mock:
-        with mock.patch('jaeger_client.reporter.LoggingReporter.close') \
-                as log_mock:
-
-            f1 = Future()
-            f2 = Future()
-            null_mock.return_value = f1
-            log_mock.return_value = f2
-            f = reporter.close()
-            null_mock.assert_called_once()
-            log_mock.assert_called_once()
-            assert not f.done()
-            f1.set_result(True)
-            f2.set_result(True)
-            assert f.done()
-
-
 class FakeSender(object):
     """
     Mock the _send() method of the reporter by capturing requests
@@ -296,3 +260,40 @@ class ReporterTest(AsyncTestCase):
         yield reporter.close()
         assert reporter.queue.qsize() == 0, 'all spans drained'
         assert count[0] == 4, 'last span submitted in one extrac batch'
+
+    @gen_test
+    def test_composite_reporter(self):
+        reporter = jaeger_client.reporter.CompositeReporter(
+            jaeger_client.reporter.NullReporter(),
+            jaeger_client.reporter.LoggingReporter())
+        with mock.patch('jaeger_client.reporter.NullReporter.set_process') \
+                as null_mock:
+            with mock.patch('jaeger_client.reporter.LoggingReporter.set_process') \
+                    as log_mock:
+                reporter.set_process('x', {}, 123)
+                null_mock.assert_called_with('x', {}, 123)
+                log_mock.assert_called_with('x', {}, 123)
+        with mock.patch('jaeger_client.reporter.NullReporter.report_span') \
+                as null_mock:
+            with mock.patch('jaeger_client.reporter.LoggingReporter.report_span') \
+                    as log_mock:
+                reporter.report_span({})
+                null_mock.assert_called_with({})
+                log_mock.assert_called_with({})
+        with mock.patch('jaeger_client.reporter.NullReporter.close') \
+                as null_mock:
+            with mock.patch('jaeger_client.reporter.LoggingReporter.close') \
+                    as log_mock:
+
+                f1 = Future()
+                f2 = Future()
+                null_mock.return_value = f1
+                log_mock.return_value = f2
+                f = reporter.close()
+                null_mock.assert_called_once()
+                log_mock.assert_called_once()
+                assert not f.done()
+                f1.set_result(True)
+                f2.set_result(True)
+                yield f
+                assert f.result()


### PR DESCRIPTION
There are minor changes related to migration from `gen.engine` (which was deprecated) to `gen.coroutine`.
Also `test_composite_reporter` has been moved to appropriate `AsyncTestCase` class due it asynchronous behavior.
As I see there is no problem to remove upper bound of Tornado, but it will lead to conflicts because some tests dependencies expected Tornado < 6 (you can see build failed on another branch https://travis-ci.org/condorcet/jaeger-client-python/jobs/513798351).
At this moment we also have inconsistent test dependencies, but it is not affected on tests:
- `tchannel` wants Tornado < 5
- `opentracing-instrumentation` (as the direct dependency and transitive dependency from `thchannel`) wants Tornado < 5.
