### PR TITLE
Refactor: Use wrapper api to access opentracing.tracer

### DIFF
--- a/crossdock/server/server.py
+++ b/crossdock/server/server.py
@@ -43,7 +43,7 @@ tracer = Tracer(
     service_name='python',
     reporter=NullReporter(),
     sampler=ConstSampler(decision=True))
-opentracing.tracer = tracer
+opentracing.set_global_tracer(tracer)
 
 
 idl_path = 'idl/thrift/crossdock/tracetest.thrift'
@@ -121,7 +121,7 @@ def get_observed_span(span):
 
 class Server(object):
     def __init__(self, port):
-        self.tracer = opentracing.tracer
+        self.tracer = opentracing.global_tracer()
         self.tchannel = self.make_tchannel(port)
 
     def make_tchannel(self, port):

--- a/jaeger_client/config.py
+++ b/jaeger_client/config.py
@@ -420,7 +420,7 @@ class Config(object):
         )
 
     def _initialize_global_tracer(self, tracer):
-        opentracing.tracer = tracer
+        opentracing.set_global_tracer(tracer)
         logger.info('opentracing.tracer initialized to %s[app_name=%s]',
                     tracer, self.service_name)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -151,7 +151,7 @@ class ConfigTests(unittest.TestCase):
         c = Config({}, service_name='x')
         tracer = c.initialize_tracer()
 
-        assert opentracing.tracer == tracer
+        assert opentracing.global_tracer() == tracer
 
     def test_default_local_agent_reporting_port(self):
         c = Config({}, service_name='x')

--- a/tests/test_crossdock.py
+++ b/tests/test_crossdock.py
@@ -100,7 +100,7 @@ def test_trace_propagation(
     body = json.dumps(level1)
 
     with mock.patch('opentracing.tracer', tracer):
-        assert opentracing.tracer == tracer  # sanity check that patch worked
+        assert opentracing.global_tracer() == tracer  # sanity check that patch worked
 
         req = HTTPRequest(url='%s/start_trace' % base_url, method='POST',
                           headers={'Content-Type': 'application/json'},


### PR DESCRIPTION
We've been setting and reading tracer using `opentracing.tracer` so far. This PR replaces such sites to use api wrapper functions instead.

Refer to DEPRECATED comment here: https://github.com/opentracing/opentracing-python/blob/master/opentracing/__init__.py#L32

Signed-off-by: Abhilash Gnan <abhilashgnan@gmail.com>