### PR TITLE
Keep track if span is finished

### DIFF
--- a/jaeger_client/span.py
+++ b/jaeger_client/span.py
@@ -24,8 +24,8 @@ from opentracing.ext import tags as ext_tags
 from . import codecs, thrift
 from .constants import SAMPLED_FLAG, DEBUG_FLAG
 
-
 logger = logging.getLogger('jaeger_tracing')
+
 
 class Span(opentracing.Span):
     """Implements opentracing.Span."""

--- a/jaeger_client/span.py
+++ b/jaeger_client/span.py
@@ -24,8 +24,8 @@ from opentracing.ext import tags as ext_tags
 from . import codecs, thrift
 from .constants import SAMPLED_FLAG, DEBUG_FLAG
 
-logger = logging.getLogger('jaeger_tracing')
 
+logger = logging.getLogger('jaeger_tracing')
 
 class Span(opentracing.Span):
     """Implements opentracing.Span."""

--- a/jaeger_client/span.py
+++ b/jaeger_client/span.py
@@ -32,7 +32,7 @@ class Span(opentracing.Span):
 
     __slots__ = ['_tracer', '_context',
                  'operation_name', 'start_time', 'end_time',
-                 'logs', 'tags', 'update_lock']
+                 'logs', 'tags', 'finished', 'update_lock']
 
     def __init__(self, context, tracer, operation_name,
                  tags=None, start_time=None, references=None):

--- a/jaeger_client/span.py
+++ b/jaeger_client/span.py
@@ -71,6 +71,9 @@ class Span(opentracing.Span):
         :param finish_time: an explicit Span finish timestamp as a unix
             timestamp per time.time()
         """
+        if not self.is_sampled():
+            return
+
         with self.update_lock:
             if self.finished:
                 logger.warning('Span has already been finished; will not be reported again.')
@@ -78,8 +81,7 @@ class Span(opentracing.Span):
             self.finished = True
             self.end_time = finish_time or time.time()
 
-        if self.is_sampled():
-            self.tracer.report_span(self)
+        self.tracer.report_span(self)
 
     def set_tag(self, key, value):
         """

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -255,6 +255,7 @@ def test_span_tag_long(tracer):
     assert span.tags[tag_n].key == 'z'
     assert span.tags[tag_n].vLong == 200
 
+
 def test_span_finish(tracer):
     tracer.sampler = ConstSampler(decision=True)
     span = tracer.start_span(operation_name='x')

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -18,6 +18,7 @@ import time
 import collections
 import json
 import mock
+import unittest
 
 from opentracing.ext import tags as ext_tags
 from jaeger_client import Span, SpanContext, ConstSampler
@@ -268,3 +269,4 @@ def test_span_finish(tracer):
     # test double finish warning
     span.finish(finish_time + 10)
     assert span.end_time == finish_time
+    unittest.TestCase.assertWarns(span.finish)

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -18,7 +18,6 @@ import time
 import collections
 import json
 import mock
-import unittest
 
 from opentracing.ext import tags as ext_tags
 from jaeger_client import Span, SpanContext, ConstSampler
@@ -269,4 +268,3 @@ def test_span_finish(tracer):
     # test double finish warning
     span.finish(finish_time + 10)
     assert span.end_time == finish_time
-    unittest.TestCase.assertWarns(span.finish)

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -14,6 +14,7 @@
 
 from __future__ import absolute_import
 
+import time
 import collections
 import json
 import mock
@@ -253,3 +254,16 @@ def test_span_tag_long(tracer):
     tag_n = len(span.tags) - 1
     assert span.tags[tag_n].key == 'z'
     assert span.tags[tag_n].vLong == 200
+
+def test_span_finish(tracer):
+    tracer.sampler = ConstSampler(decision=True)
+    span = tracer.start_span(operation_name='x')
+    assert span.is_sampled()
+
+    finish_time = time.time()
+    span.finish(finish_time)
+    assert span.finished is True
+
+    # test double finish warning
+    span.finish(finish_time + 10)
+    assert span.end_time == finish_time


### PR DESCRIPTION
This PR adds a guard to `span.finish()` function to check if span has finished, and not report a span more than once.
We do have similar check in [java client](https://sourcegraph.com/github.com/jaegertracing/jaeger-client-java/-/blob/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerSpan.java#L179) for example.

Fixes https://github.com/jaegertracing/jaeger-client-python/issues/251

Signed-off-by: Abhilash Gnan <abhilashgnan@gmail.com>