### PR TITLE
Always schedule span reporting in io_loop

### DIFF
--- a/jaeger_client/reporter.py
+++ b/jaeger_client/reporter.py
@@ -130,12 +130,7 @@ class Reporter(NullReporter):
             )
 
     def report_span(self, span):
-        # We should not be calling `queue.put_nowait()` from random threads,
-        # only from the same IOLoop where the queue is consumed (T333431).
-        if tornado.ioloop.IOLoop.current(instance=False) == self.io_loop:
-            self._report_span_from_ioloop(span)
-        else:
-            self.io_loop.add_callback(self._report_span_from_ioloop, span)
+        self.io_loop.add_callback(self._report_span_from_ioloop, span)
 
     def _report_span_from_ioloop(self, span):
         try:

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -156,6 +156,8 @@ class ReporterTest(AsyncTestCase):
         span_dropped_key = 'jaeger:reporter_spans.result_dropped'
         assert span_dropped_key not in reporter.metrics_factory.counters
         reporter.report_span(self._new_span('1'))
+        yield self._wait_for(
+            lambda: span_dropped_key in reporter.metrics_factory.counters)
         assert 1 == reporter.metrics_factory.counters[span_dropped_key]
 
     @gen_test
@@ -248,6 +250,7 @@ class ReporterTest(AsyncTestCase):
         reporter.batch_size = 3
         for i in range(10):
             reporter.report_span(self._new_span('%s' % i))
+        yield self._wait_for(lambda: reporter.queue.qsize() > 0)
         assert reporter.queue.qsize() == 10, 'queued 10 spans'
 
         # now unblock consumer


### PR DESCRIPTION
Fixes https://github.com/jaegertracing/jaeger-client-python/issues/256
