### PR TITLE
Remove Tornado upper boundary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,14 @@ matrix:
     env: TORNADO=">=4,<5"
   - python: "3.5"
     env: TORNADO=">=5,<6"
+  - python: "3.5"
+    env: TORNADO=">=6"
   - python: "3.6"
     env: TORNADO=">=4,<5"
   - python: "3.6"
     env: TORNADO=">=5,<6"
+  - python: "3.6"
+    env: TORNADO=">=6"
 
 install:
   - make bootstrap

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     install_requires=[
         'threadloop>=1,<2',
         'thrift',
-        'tornado>=4.3,<6',
+        'tornado>=4.3',
         'opentracing>=2.1,<3.0',
     ],
     # Uncomment below if need to test with unreleased version of opentracing
@@ -66,7 +66,7 @@ setup(
             'flake8',
             'flake8-quotes',
             'codecov',
-            'tchannel>=0.27',  # This is only used in python 2
+            'tchannel>=0.27;python_version=="2.7"',  # This is only used in python 2
             'opentracing_instrumentation>=3,<4',
             'prometheus_client==0.3.1',
         ]

--- a/tests/test_crossdock.py
+++ b/tests/test_crossdock.py
@@ -20,7 +20,6 @@ import json
 import os
 import pytest
 import opentracing
-from opentracing.scope_managers.tornado import TornadoScopeManager
 from mock import MagicMock
 from tornado.httpclient import HTTPRequest
 from jaeger_client import Tracer, ConstSampler
@@ -29,6 +28,10 @@ from crossdock.server.endtoend import EndToEndHandler, _determine_host_port, _pa
 
 if six.PY2:
     from crossdock.server import server
+    from opentracing.scope_managers.tornado import TornadoScopeManager
+    scope_manager = TornadoScopeManager
+else:
+    scope_manager = None
 
 tchannel_port = '9999'
 
@@ -48,7 +51,7 @@ def tracer():
         service_name='test-tracer',
         sampler=ConstSampler(True),
         reporter=InMemoryReporter(),
-        scope_manager=TornadoScopeManager()
+        scope_manager=scope_manager() if scope_manager else None
     )
     try:
         yield tracer


### PR DESCRIPTION
As I can see we don't have any problem with Tornado 6 because it use asyncio under the hood like Tornado 5 in python 3.
About tests:
At this moment we use `TornadoScopeManager` in `test_crossdock.py` for tests that only run in python 2 (because of `tchannel`). Tornado 6 doesn't have `stack_context` anymore so we get import error.
For other few tests in this file scope manager and tracer unnecessary, so we can make conditional import of `TornadoScopeManager` only for python 2.
Maybe when this tests be ready for python 3, it's better to use `AsyncioScopeManager` for them.