### PR TITLE
Allow adding 'service' label to Prometheus metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ if __name__ == "__main__":
                 'param': 1,
             },
             'logging': True,
-        },  
+        },
         service_name='your-app-name',
         validate=True,
     )
@@ -67,7 +67,7 @@ if __name__ == "__main__":
                 'reporting_port': 'your-reporting-port',
             },
             'logging': True,
-        },  
+        },
         service_name='your-app-name',
         validate=True,
     )
@@ -89,7 +89,7 @@ after all the imports are done.
 
 
 Also note that using `gevent.monkey` in asyncio-based applications (python 3+) may need to pass current event loop explicitly (see issue #256):
- 
+
  ```python
 from tornado import ioloop
 from jaeger_client import Config
@@ -115,7 +115,7 @@ If you need to create additional tracers (e.g., to create spans on the client si
 
 #### Prometheus metrics
 
-This module brings a [Prometheus](https://github.com/prometheus/client_python) integration to the internal Jaeger metrics.  
+This module brings a [Prometheus](https://github.com/prometheus/client_python) integration to the internal Jaeger metrics.
 The way to initialize the tracer with Prometheus metrics:
 
 ```python
@@ -125,7 +125,7 @@ config = Config(
         config={},
         service_name='your-app-name',
         validate=True,
-        metrics_factory=PrometheusMetricsFactory(namespace='your-app-name')
+        metrics_factory=PrometheusMetricsFactory(name_label='your-app-name')
 )
 tracer = config.initialize_tracer()
 ```
@@ -136,8 +136,8 @@ For development, some parameters can be passed via `config` dictionary, as in th
 
 ### WSGI, multi-processing, fork(2)
 
-When using this library in applications that fork child processes to handle individual requests, 
-such as with [WSGI / PEP 3333](https://wsgi.readthedocs.io/), care must be taken when initializing the tracer. 
+When using this library in applications that fork child processes to handle individual requests,
+such as with [WSGI / PEP 3333](https://wsgi.readthedocs.io/), care must be taken when initializing the tracer.
 When Jaeger tracer is initialized, it may start a new background thread. If the process later forks,
 it might cause issues or hang the application (due to exclusive lock on the interpreter).
 Therefore, it is recommended that the tracer is not initialized until after the child processes

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ config = Config(
         config={},
         service_name='your-app-name',
         validate=True,
-        metrics_factory=PrometheusMetricsFactory(name_label='your-app-name')
+        metrics_factory=PrometheusMetricsFactory(service_name_label='your-app-name')
 )
 tracer = config.initialize_tracer()
 ```

--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ config = Config(
 tracer = config.initialize_tracer()
 ```
 
+Note that the optional argument `service_name_label` to the factory constructor
+will force it to tag all Jaeger client metrics with a label `service: your-app-name`.
+This way you can distinguish Jaeger client metrics produced by different services.
+
 ### Development
 
 For development, some parameters can be passed via `config` dictionary, as in the Getting Started example above. For more details please see the [Config class](jaeger_client/config.py).

--- a/jaeger_client/metrics/prometheus.py
+++ b/jaeger_client/metrics/prometheus.py
@@ -21,9 +21,10 @@ class PrometheusMetricsFactory(MetricsFactory):
     """
     Provides metrics backed by Prometheus
     """
-    def __init__(self, namespace=''):
+    def __init__(self, namespace='', name_label=''):
         self._cache = defaultdict(object)
         self._namespace = namespace
+        self._name_label = name_label
 
     def _get_tag_name_list(self, tags):
         if tags is None:
@@ -41,20 +42,28 @@ class PrometheusMetricsFactory(MetricsFactory):
         return self._cache[cache_key]
 
     def create_counter(self, name, tags=None):
+        name_label = {'service': self._name_label}
+        if tags is None:
+            tags = name_label
+        else:
+            tags.update(name_label)
         label_name_list = self._get_tag_name_list(tags)
         counter = self._get_metric(Counter, name, label_name_list)
-        if tags is not None and len(tags) > 0:
-            counter = counter.labels(**tags)
+        counter = counter.labels(**tags)
 
         def increment(value):
             counter.inc(value)
         return increment
 
     def create_gauge(self, name, tags=None):
+        name_label = {'service': self._name_label}
+        if tags is None:
+            tags = name_label
+        else:
+            tags.update(name_label)
         label_name_list = self._get_tag_name_list(tags)
         gauge = self._get_metric(Gauge, name, label_name_list)
-        if tags is not None and len(tags) > 0:
-            gauge = gauge.labels(**tags)
+        gauge = gauge.labels(**tags)
 
         def update(value):
             gauge.set(value)

--- a/jaeger_client/metrics/prometheus.py
+++ b/jaeger_client/metrics/prometheus.py
@@ -36,14 +36,13 @@ class PrometheusMetricsFactory(MetricsFactory):
 
     def _get_metric(self, metricType, name, tags):
         if self._service_name_label:
-            name_label = {'service': self._service_name_label}
             if tags is None:
                 tags = {'service': self._service_name_label}
             else:
                 tags['service'] = self._service_name_label
 
         label_name_list = self._get_tag_name_list(tags)
-        cache_key = name + ''.join(label_name_list)
+        cache_key = name + '@@'.join(label_name_list)
 
         metric = self._cache.get(cache_key)
         if metric is None:

--- a/jaeger_client/metrics/prometheus.py
+++ b/jaeger_client/metrics/prometheus.py
@@ -21,7 +21,7 @@ class PrometheusMetricsFactory(MetricsFactory):
     """
     Provides metrics backed by Prometheus
     """
-    def __init__(self, namespace='', name_label=''):
+    def __init__(self, namespace='', name_label=None):
         self._cache = defaultdict(object)
         self._namespace = namespace
         self._name_label = name_label

--- a/jaeger_client/metrics/prometheus.py
+++ b/jaeger_client/metrics/prometheus.py
@@ -21,10 +21,10 @@ class PrometheusMetricsFactory(MetricsFactory):
     """
     Provides metrics backed by Prometheus
     """
-    def __init__(self, namespace='', name_label=None):
+    def __init__(self, namespace='', service_name_label=None):
         self._cache = defaultdict(object)
         self._namespace = namespace
-        self._name_label = name_label
+        self._service_name_label = service_name_label
 
     def _get_tag_name_list(self, tags):
         if tags is None:
@@ -42,8 +42,8 @@ class PrometheusMetricsFactory(MetricsFactory):
         return self._cache[cache_key]
 
     def create_counter(self, name, tags=None):
-        if self._name_label:
-            name_label = {'service': self._name_label}
+        if self._service_name_label:
+            name_label = {'service': self._service_name_label}
             if tags is None:
                 tags = name_label
             else:
@@ -58,8 +58,8 @@ class PrometheusMetricsFactory(MetricsFactory):
         return increment
 
     def create_gauge(self, name, tags=None):
-        if self._name_label:
-            name_label = {'service': self._name_label}
+        if self._service_name_label:
+            name_label = {'service': self._service_name_label}
             if tags is None:
                 tags = name_label
             else:

--- a/jaeger_client/metrics/prometheus.py
+++ b/jaeger_client/metrics/prometheus.py
@@ -42,28 +42,32 @@ class PrometheusMetricsFactory(MetricsFactory):
         return self._cache[cache_key]
 
     def create_counter(self, name, tags=None):
-        name_label = {'service': self._name_label}
-        if tags is None:
-            tags = name_label
-        else:
-            tags.update(name_label)
+        if self._name_label:
+            name_label = {'service': self._name_label}
+            if tags is None:
+                tags = name_label
+            else:
+                tags.update(name_label)
         label_name_list = self._get_tag_name_list(tags)
         counter = self._get_metric(Counter, name, label_name_list)
-        counter = counter.labels(**tags)
+        if tags is not None and len(tags) > 0:
+            counter = counter.labels(**tags)
 
         def increment(value):
             counter.inc(value)
         return increment
 
     def create_gauge(self, name, tags=None):
-        name_label = {'service': self._name_label}
-        if tags is None:
-            tags = name_label
-        else:
-            tags.update(name_label)
+        if self._name_label:
+            name_label = {'service': self._name_label}
+            if tags is None:
+                tags = name_label
+            else:
+                tags.update(name_label)
         label_name_list = self._get_tag_name_list(tags)
         gauge = self._get_metric(Gauge, name, label_name_list)
-        gauge = gauge.labels(**tags)
+        if tags is not None and len(tags) > 0:
+            gauge = gauge.labels(**tags)
 
         def update(value):
             gauge.set(value)

--- a/tests/test_prometheus.py
+++ b/tests/test_prometheus.py
@@ -55,18 +55,20 @@ def test_prometheus_metrics_gauge_without_tags():
     after = REGISTRY.get_sample_value('jaeger:test_gauge_no_tags')
     assert 1 == after
 
+
 def test_prometheus_metrics_metric_with_service_name_label():
-    metrics = PrometheusMetricsFactory(service_name_label="test")
+    metrics = PrometheusMetricsFactory(service_name_label='test')
     gauge = metrics.create_gauge(name='jaeger:test_gauge_with_service_name_label')
     gauge(1)
     gauge_after = REGISTRY.get_sample_value('jaeger:test_gauge_with_service_name_label',
-                                            {"service": "test"})
+                                            {'service': 'test'})
     counter = metrics.create_counter(name='jaeger:test_counter_with_service_name_label')
     counter(1)
     counter_after = REGISTRY.get_sample_value('jaeger:test_counter_with_service_name_label',
-                                              {"service": "test"})
+                                              {'service': 'test'})
     assert 1 == counter_after
     assert 1 == gauge_after
+
 
 def test_prometheus_metrics_metric_without_service_name_label():
     metrics = PrometheusMetricsFactory()

--- a/tests/test_prometheus.py
+++ b/tests/test_prometheus.py
@@ -54,3 +54,27 @@ def test_prometheus_metrics_gauge_without_tags():
     gauge(1)
     after = REGISTRY.get_sample_value('jaeger:test_gauge_no_tags')
     assert 1 == after
+
+def test_prometheus_metrics_metric_with_service_name_label():
+    metrics = PrometheusMetricsFactory(service_name_label="test")
+    gauge = metrics.create_gauge(name='jaeger:test_gauge_with_service_name_label')
+    gauge(1)
+    gauge_after = REGISTRY.get_sample_value('jaeger:test_gauge_with_service_name_label',
+                                            {"service": "test"})
+    counter = metrics.create_counter(name='jaeger:test_counter_with_service_name_label')
+    counter(1)
+    counter_after = REGISTRY.get_sample_value('jaeger:test_counter_with_service_name_label',
+                                              {"service": "test"})
+    assert 1 == counter_after
+    assert 1 == gauge_after
+
+def test_prometheus_metrics_metric_without_service_name_label():
+    metrics = PrometheusMetricsFactory()
+    gauge = metrics.create_gauge(name='jaeger:test_gauge_without_service_name_label')
+    gauge(1)
+    gauge_after = REGISTRY.get_sample_value('jaeger:test_gauge_without_service_name_label')
+    counter = metrics.create_counter(name='jaeger:test_counter_without_service_name_label')
+    counter(1)
+    counter_after = REGISTRY.get_sample_value('jaeger:test_counter_without_service_name_label')
+    assert 1 == counter_after
+    assert 1 == gauge_after

--- a/tests/test_prometheus.py
+++ b/tests/test_prometheus.py
@@ -62,10 +62,11 @@ def test_prometheus_metrics_metric_with_service_name_label():
     gauge(1)
     gauge_after = REGISTRY.get_sample_value('jaeger:test_gauge_with_service_name_label',
                                             {'service': 'test'})
-    counter = metrics.create_counter(name='jaeger:test_counter_with_service_name_label')
+    counter = metrics.create_counter(name='jaeger:test_counter_with_service_name_label',
+                                     tags={'x': 'y'})
     counter(1)
     counter_after = REGISTRY.get_sample_value('jaeger:test_counter_with_service_name_label',
-                                              {'service': 'test'})
+                                              {'service': 'test', 'x': 'y'})
     assert 1 == counter_after
     assert 1 == gauge_after
 


### PR DESCRIPTION
Add support for the prometheus metrics to have a label called `service`, which can be used to identify every microservice.