### PR TITLE
Log a warning when string tags are truncated

### DIFF
--- a/jaeger_client/span.py
+++ b/jaeger_client/span.py
@@ -98,6 +98,10 @@ class Span(opentracing.Span):
                     max_length=self.tracer.max_tag_value_length,
                     max_traceback_length=self._tracer.max_traceback_length,
                 )
+                if isinstance(value, six.string_types) and \
+                        len(value) > self.tracer.max_tag_value_length:
+                    logger.warning('Truncated tag {} with length {} > {} in span {}'.format(
+                        key, len(value), self.tracer.max_tag_value_length, self))
                 self.tags.append(tag)
         return self
 


### PR DESCRIPTION
Mostly putting this up for discussion.

With SQL queries reported as tags in the SQLAlchemy instrumentation as of uber-common/opentracing-python-instrumentation#107, I'm seeing a lot of truncated queries and I want to adjust `max_tag_value_length` in an informed manner. The intent with this change is to make it easier to tune `max_tag_value_length` based on knowledge of what tags are being truncated and what the actual length of the value is.

That said, if it's common or expected that tag values will be truncated, maybe this isn't the right approach, as I'd want to avoid spamming the logs with warnings that no one will ever pay attention to. Other thoughts I've had have been adding tags or log entries that indicate that a tag value is being truncated (so it would be visible in the UI).