### PR TITLE
Added python logging autologger

### DIFF
--- a/jaeger_client/span_autologger.py
+++ b/jaeger_client/span_autologger.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2016-2018 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 from logging import StreamHandler
 import datetime

--- a/jaeger_client/span_autologger.py
+++ b/jaeger_client/span_autologger.py
@@ -1,0 +1,53 @@
+import logging
+from logging import StreamHandler
+import datetime
+
+import logging
+
+logger = logging.getLogger('jaeger_tracing')
+
+class SpanAutologger(StreamHandler):
+    # Custom StreamHandler implementation to forward python logger records to Jaeger / OpenTracing
+    __slots__ = ["_span", "span_logger"]
+    def __init__(self, span_logger, span):
+        StreamHandler.__init__(self)
+        self._span = span
+        self.span_logger = span_logger
+
+    def emit(self, record):
+        # See here https://docs.python.org/3/library/logging.html#logrecord-objects
+        if hasattr(record, 'msg'):
+            logger.debug("emitting log")
+            message = self.format(record)
+            self._span.log_kv({
+                "asctime": getattr(record, 'asctime', datetime.datetime.now()),
+                "created": record.created,
+                "filename": record.filename,
+                "funcName": record.funcName,
+                "levelname": record.levelname,
+                "lineno": record.lineno,
+                "message": message,
+                "msg": record.msg,
+                "module": record.module,
+                "msecs": record.msecs,
+                "name": record.name,
+                "pathname": record.pathname,
+                "process": record.process,
+                "processName": record.processName,
+                "thread": record.thread,
+                "threadName": record.threadName,
+            })
+    def __enter__(self):
+        logger.debug("adding jaeger streamhandler to logger object to capture log")
+        self.span_logger.addHandler(self)
+
+    def __exit__(self, type=None, value=None, traceback=None):
+        logger.debug("removing jaeger streamhandler from logger object")
+        self.span_logger.removeHandler(self)
+        if type:
+            logger.debug("span exited with an exception, log the exception")
+            self._span.log_kv({
+                "exception": type,
+                "value": value,
+                "traceback": traceback
+            })

--- a/jaeger_client/span_autologger.py
+++ b/jaeger_client/span_autologger.py
@@ -51,17 +51,11 @@ class SpanAutologger(StreamHandler):
                 "thread": record.thread,
                 "threadName": record.threadName,
             })
-    def __enter__(self):
+
+    def start(self):
         logger.debug("adding jaeger streamhandler to logger object to capture log")
         self.span_logger.addHandler(self)
 
-    def __exit__(self, type=None, value=None, traceback=None):
+    def finish(self):
         logger.debug("removing jaeger streamhandler from logger object")
         self.span_logger.removeHandler(self)
-        if type:
-            logger.debug("span exited with an exception, log the exception")
-            self._span.log_kv({
-                "exception": type,
-                "value": value,
-                "traceback": traceback
-            })

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -124,6 +124,7 @@ class Tracer(opentracing.Tracer):
                    tags=None,
                    start_time=None,
                    ignore_active_span=False,
+                   span_logger=None
                    ):
         """
         Start and return a new Span representing a unit of work.
@@ -208,7 +209,9 @@ class Tracer(opentracing.Tracer):
                                baggage=baggage)
         span = Span(context=span_ctx, tracer=self,
                     operation_name=operation_name,
-                    tags=tags, start_time=start_time, references=valid_references)
+                    tags=tags, start_time=start_time,
+                    references=valid_references, span_logger=span_logger
+                )
 
         self._emit_span_metrics(span=span, join=rpc_server)
 


### PR DESCRIPTION
#279 

The goal of this pull request is to give developers an easy way of capturing logging output from their instrumented applications using the Jaeger client library.

This change will add a new optional parameter when creating `Span` objects - `span_logger`. This may be set to either a python `logger` object, or `None`. If set to a python logger object, messages sent to that logger will also be sent to the tracer under the current span, whilst the span is active. This is achieved using a custom logging handler to capture emit events. Once the span is closed, the the custom log handler is removed from the logging object and log entries are no longer sent to the tracer.

- Added unit test
- Added a section in `README.md`
