### PR TITLE
#279 Add jaeger_client python log capture. Allows you to autocapture …

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ if __name__ == "__main__":
     )
 ```
 
+### Automatic python log capture
+
 If your project makes use of the python logger, you can set up your span objects to automatically capture the output of python loggers whilst they are active.
 
 ```python

--- a/jaeger_client/__init__.py
+++ b/jaeger_client/__init__.py
@@ -21,7 +21,7 @@ import sys
 import jaeger_client.thrift_gen as modpath
 sys.path.append(modpath.__path__[0])
 
-__version__ = '4.3.1.dev0'
+__version__ = '4.3.2.dev0'
 
 from .tracer import Tracer  # noqa
 from .config import Config  # noqa

--- a/jaeger_client/span.py
+++ b/jaeger_client/span.py
@@ -23,6 +23,7 @@ import opentracing
 from opentracing.ext import tags as ext_tags
 from . import codecs, thrift
 from .constants import SAMPLED_FLAG, DEBUG_FLAG
+from .span_autologger import SpanAutologger
 
 logger = logging.getLogger('jaeger_tracing')
 
@@ -32,9 +33,9 @@ class Span(opentracing.Span):
 
     __slots__ = ['_tracer', '_context',
                  'operation_name', 'start_time', 'end_time',
-                 'logs', 'tags', 'finished', 'update_lock']
+                 'logs', 'tags', 'finished', 'update_lock', 'span_autologger']
 
-    def __init__(self, context, tracer, operation_name,
+    def __init__(self, context, tracer, operation_name, span_logger=None,
                  tags=None, start_time=None, references=None):
         super(Span, self).__init__(context=context, tracer=tracer)
         self.operation_name = operation_name
@@ -46,6 +47,12 @@ class Span(opentracing.Span):
         # we store tags and logs as Thrift objects to avoid extra allocations
         self.tags = []
         self.logs = []
+        if span_logger:
+            self.span_autologger = SpanAutologger(
+                span_logger=span_logger, span=self)
+            self.span_autologger.start()
+        else:
+            self.span_autologger = None
         if tags:
             for k, v in six.iteritems(tags):
                 self.set_tag(k, v)
@@ -71,6 +78,10 @@ class Span(opentracing.Span):
         :param finish_time: an explicit Span finish timestamp as a unix
             timestamp per time.time()
         """
+
+        if self.span_autologger:
+            self.span_autologger.finish()
+
         if not self.is_sampled():
             return
 
@@ -213,3 +224,8 @@ class Span(opentracing.Span):
         else:
             self.log(event=message)
         return self
+
+    def __exit__(self, *args, **kwargs):
+        if self.span_autologger:
+            self.span_autologger.__exit__(*args, **kwargs)
+        return super(Span, self).__exit__(*args, **kwargs)

--- a/jaeger_client/span_autologger.py
+++ b/jaeger_client/span_autologger.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2016-2018 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from logging import StreamHandler
+import datetime
+
+import logging
+
+logger = logging.getLogger('jaeger_tracing')
+
+class SpanAutologger(StreamHandler):
+    # Custom StreamHandler implementation to forward python logger records to Jaeger / OpenTracing
+    __slots__ = ["_span", "span_logger"]
+    def __init__(self, span_logger, span):
+        StreamHandler.__init__(self)
+        self._span = span
+        self.span_logger = span_logger
+
+    def emit(self, record):
+        # See here https://docs.python.org/3/library/logging.html#logrecord-objects
+        if hasattr(record, 'msg'):
+            logger.debug("emitting log")
+            message = self.format(record)
+            self._span.log_kv({
+                "asctime": getattr(record, 'asctime', datetime.datetime.now()),
+                "created": record.created,
+                "filename": record.filename,
+                "funcName": record.funcName,
+                "levelname": record.levelname,
+                "lineno": record.lineno,
+                "message": message,
+                "msg": record.msg,
+                "module": record.module,
+                "msecs": record.msecs,
+                "name": record.name,
+                "pathname": record.pathname,
+                "process": record.process,
+                "processName": record.processName,
+                "thread": record.thread,
+                "threadName": record.threadName,
+            })
+
+    def start(self):
+        logger.debug("adding jaeger streamhandler to logger object to capture log")
+        self.span_logger.addHandler(self)
+
+    def finish(self):
+        logger.debug("removing jaeger streamhandler from logger object")
+        self.span_logger.removeHandler(self)

--- a/jaeger_client/span_autologger.py
+++ b/jaeger_client/span_autologger.py
@@ -16,13 +16,13 @@ import logging
 from logging import StreamHandler
 import datetime
 
-import logging
-
 logger = logging.getLogger('jaeger_tracing')
+
 
 class SpanAutologger(StreamHandler):
     # Custom StreamHandler implementation to forward python logger records to Jaeger / OpenTracing
-    __slots__ = ["_span", "span_logger"]
+    __slots__ = ['_span', 'span_logger']
+
     def __init__(self, span_logger, span):
         StreamHandler.__init__(self)
         self._span = span
@@ -31,31 +31,31 @@ class SpanAutologger(StreamHandler):
     def emit(self, record):
         # See here https://docs.python.org/3/library/logging.html#logrecord-objects
         if hasattr(record, 'msg'):
-            logger.debug("emitting log")
+            logger.debug('emitting log')
             message = self.format(record)
             self._span.log_kv({
-                "asctime": getattr(record, 'asctime', datetime.datetime.now()),
-                "created": record.created,
-                "filename": record.filename,
-                "funcName": record.funcName,
-                "levelname": record.levelname,
-                "lineno": record.lineno,
-                "message": message,
-                "msg": record.msg,
-                "module": record.module,
-                "msecs": record.msecs,
-                "name": record.name,
-                "pathname": record.pathname,
-                "process": record.process,
-                "processName": record.processName,
-                "thread": record.thread,
-                "threadName": record.threadName,
+                'asctime': getattr(record, 'asctime', datetime.datetime.now()),
+                'created': record.created,
+                'filename': record.filename,
+                'funcName': record.funcName,
+                'levelname': record.levelname,
+                'lineno': record.lineno,
+                'message': message,
+                'msg': record.msg,
+                'module': record.module,
+                'msecs': record.msecs,
+                'name': record.name,
+                'pathname': record.pathname,
+                'process': record.process,
+                'processName': record.processName,
+                'thread': record.thread,
+                'threadName': record.threadName,
             })
 
     def start(self):
-        logger.debug("adding jaeger streamhandler to logger object to capture log")
+        logger.debug('adding jaeger streamhandler to logger object to capture log')
         self.span_logger.addHandler(self)
 
     def finish(self):
-        logger.debug("removing jaeger streamhandler from logger object")
+        logger.debug('removing jaeger streamhandler from logger object')
         self.span_logger.removeHandler(self)

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -124,6 +124,7 @@ class Tracer(opentracing.Tracer):
                    tags=None,
                    start_time=None,
                    ignore_active_span=False,
+                   span_logger=None
                    ):
         """
         Start and return a new Span representing a unit of work.
@@ -208,7 +209,9 @@ class Tracer(opentracing.Tracer):
                                baggage=baggage)
         span = Span(context=span_ctx, tracer=self,
                     operation_name=operation_name,
-                    tags=tags, start_time=start_time, references=valid_references)
+                    tags=tags, start_time=start_time,
+                    references=valid_references, span_logger=span_logger
+                )
 
         self._emit_span_metrics(span=span, join=rpc_server)
 

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -210,8 +210,7 @@ class Tracer(opentracing.Tracer):
         span = Span(context=span_ctx, tracer=self,
                     operation_name=operation_name,
                     tags=tags, start_time=start_time,
-                    references=valid_references, span_logger=span_logger
-                )
+                    references=valid_references, span_logger=span_logger)
 
         self._emit_span_metrics(span=span, join=rpc_server)
 

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -327,7 +327,7 @@ def test_span_autologging(tracer):
         assert len(span.logs) == 1, name
         log = span.logs[0]
         log_fields = _fields_to_dict(log)
-        assert list(log_fields.keys()) == expected_fields
+        assert set(log_fields.keys()) == set(expected_fields)
 
         if test.timestamp:
             assert log.timestamp == test.timestamp

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -24,6 +24,7 @@ from jaeger_client import Span, SpanContext, ConstSampler
 
 import logging
 
+
 def test_baggage():
     mock_tracer = mock.MagicMock()
     mock_tracer.max_tag_value_length = 100
@@ -270,15 +271,16 @@ def test_span_finish(tracer):
     span.finish(finish_time + 10)
     assert span.end_time == finish_time
 
+
 def test_span_autologging(tracer):
     tpl = collections.namedtuple(
         'Test',
         ['method', 'args', 'kwargs', 'expected', 'error', 'timestamp'])
 
     expected_fields = [
-        "asctime", "created", "filename", "funcName", "levelname",
-        "lineno", "message", "msg", "module", "msecs", "name",
-        "pathname", "process", "processName", "thread", "threadName"]
+        'asctime', 'created', 'filename', 'funcName', 'levelname',
+        'lineno', 'message', 'msg', 'module', 'msecs', 'name',
+        'pathname', 'process', 'processName', 'thread', 'threadName']
 
     def test(method, expected,
              args=None, kwargs=None, error=False, timestamp=None):


### PR DESCRIPTION
#279

The goal of this pull request is to give developers an easy way of capturing logging output from their instrumented applications using the Jaeger client library.

This change will add a new optional parameter when creating Span objects - span_logger. This may be set to either a python logger object, or None. If set to a python logger object, messages sent to that logger will also be sent to the tracer under the current span, whilst the span is active. This is achieved using a custom logging handler to capture emit events. Once the span is closed, the the custom log handler is removed from the logging object and log entries are no longer sent to the tracer.

Added unit test
Added a section in README.md

Signed-off-by: Luke Plausin <luke.plausin@gmail.com>