### PR TITLE
Update log warning function call

### DIFF
--- a/jaeger_client/config.py
+++ b/jaeger_client/config.py
@@ -356,7 +356,7 @@ class Config(object):
 
         with Config._initialized_lock:
             if Config._initialized:
-                logger.warn('Jaeger tracer already initialized, skipping')
+                logger.warning('Jaeger tracer already initialized, skipping')
                 return
             Config._initialized = True
 


### PR DESCRIPTION
`logger.warn()` is a deprecated interface, updating it to `logger.warning()`

Signed-off-by: Tim Saylor <tim.saylor@gmail.com>