### PR TITLE
Fix child_span example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ if __name__ == "__main__":
         span.log_kv({'event': 'test message', 'life': 42})
 
         with tracer.start_span('ChildSpan', child_of=span) as child_span:
-            span.log_kv({'event': 'down below'})
+            child_span.log_kv({'event': 'down below'})
 
     time.sleep(2)   # yield to IOLoop to flush the spans - https://github.com/jaegertracing/jaeger-client-python/issues/50
     tracer.close()  # flush any buffered spans


### PR DESCRIPTION
Example appears to want to demonstrate use of a child span, but uses variable for parent span instead.