### PR TITLE
Add a W3C Trace Context compatible codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ current parent id with the generation of the new span id.
 extract( {"traceparent": "trace_id-span_id"} ) => SpanContext( trace_id, parent_id=span_id, span_id=generate_span_id() )
 ```
 
-This example shows how it works over several calls.
+This example shows how this works over several calls.
 
 ```
 trace_id = init_trace_id()

--- a/README.md
+++ b/README.md
@@ -192,6 +192,46 @@ The B3 codec assumes it will receive lowercase HTTP headers, as this seems
 to be the standard in the popular frameworks like Flask and Django.
 Please make sure your framework does the same.
 
+## W3C Compatibility
+
+To use this library with other
+[W3C Trace Context](https://www.w3.org/TR/trace-context/)
+compatible libraries, you can provide the configuration property
+`propagation: 'w3c'` and the `traceparent` and `tracestate` HTTP
+headers will be supported. It should be noted that the W3C standard
+does not currently contain any support for baggage, so any baggage
+used in the operation will be left behind when calling the next system.
+
+The standard also only contains 2 ids, the current trace id and the
+parent id. Therefore, the span id of the current becomes the parent id
+in the next, and a new span id will be generated during extraction
+for the current span context.
+
+Here are a couple of pseudo examples to illustrate this:
+
+An injection showing the dropping of the parent id when creating
+the traceparent
+
+```
+inject(SpanContext(trace_id, parent_id, span_id)) => traceparent="trace_id-span_id"
+```
+
+An extraction showing the passed in span id becomes the
+current parent id with the generation of the new span id.
+
+```
+extract({traceparent: "trace_id-span_id"}) => SpanContext(trace_id, parent_id=span_id, span_id=generate_span_id())
+```
+
+The `tracestate` is set and passed according to the standard, where
+the latest trace is always at the left most position overriding any
+previous states. This is implemented using a class surrounding (but
+not extending) an OrderedDict. It should be noted that while the
+handling class can accept an encoder at initalization for the state
+values, there is currently no mechanism to pass this into the class
+and therefore the plain hexadecimal value that is also provided in
+the `traceparent` will always be used.
+
 ## License
 
 [Apache 2.0 License](./LICENSE).

--- a/jaeger_client/codecs.py
+++ b/jaeger_client/codecs.py
@@ -332,11 +332,10 @@ W3CTraceFormat = 'w3c-trace-format'
 
 
 class W3CTraceCodec(Codec):
-    _TRACEPARENT_HEADER_NAME = "traceparent"
-    _TRACESTATE_HEADER_NAME = "tracestate"
+    _TRACEPARENT_HEADER_NAME = 'traceparent'
+    _TRACESTATE_HEADER_NAME = 'tracestate'
     _TRACEPARENT_HEADER_FORMAT = (
-            "^[ \t]*([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})"
-            + "(-.*)?[ \t]*$"
+        '^[ \t]*([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})(-.*)?[ \t]*$'
     )
     _TRACEPARENT_HEADER_FORMAT_RE = re.compile(_TRACEPARENT_HEADER_FORMAT)
 
@@ -346,19 +345,19 @@ class W3CTraceCodec(Codec):
 
     @staticmethod
     def get_hexadecimal_trace_id(trace_id):
-        return "{:032x}".format(trace_id)
+        return '{:032x}'.format(trace_id)
 
     @staticmethod
     def get_hexadecimal_span_id(span_id):
-        return "{:016x}".format(span_id)
+        return '{:016x}'.format(span_id)
 
     @staticmethod
     def get_hexadecimal_trace_flags(trace_flags):
-        return "{:02x}".format(trace_flags)
+        return '{:02x}'.format(trace_flags)
 
     @staticmethod
     def get_int_from_hexadecimal(value):
-        return int("0x{}".format(value), 16)
+        return int('0x{}'.format(value), 16)
 
     @staticmethod
     def _random_id(bitsize):
@@ -375,9 +374,9 @@ class W3CTraceCodec(Codec):
         trace_id = self.get_hexadecimal_trace_id(span_context.trace_id)
         span_id = self.get_hexadecimal_span_id(span_context.span_id)
         trace_flags = self.get_hexadecimal_trace_flags(trace_flags)
-        carrier[self._TRACEPARENT_HEADER_NAME] = "00-{}-{}-{}".format(
+        carrier[self._TRACEPARENT_HEADER_NAME] = '00-{}-{}-{}'.format(
             trace_id, span_id, trace_flags).lower()
-        trace_state = getattr(span_context, "trace_state", TraceState())
+        trace_state = getattr(span_context, 'trace_state', TraceState())
         trace_state.add(span_context.operation_name, span_id)
         carrier[self._TRACESTATE_HEADER_NAME] = trace_state.get_formatted_header()
 
@@ -398,7 +397,7 @@ class W3CTraceCodec(Codec):
                     trace_id = match.group(2)
                     parent_id = match.group(3)
                     flags = match.group(4)
-                    if version != "00" or trace_id == "0" * 32 or parent_id == "0" * 16:
+                    if version != '00' or trace_id == '0' * 32 or parent_id == '0' * 16:
                         trace_id, parent_id = None, None
                     else:
                         trace_id = self.get_int_from_hexadecimal(trace_id)

--- a/jaeger_client/config.py
+++ b/jaeger_client/config.py
@@ -315,7 +315,7 @@ class Config(object):
         if propagation == 'b3':
             # replace the codec with a B3 enabled instance
             return {Format.HTTP_HEADERS: B3Codec()}
-        if propagation == "w3c":
+        if propagation == 'w3c':
             return {Format.HTTP_HEADERS: W3CTraceCodec()}
         return {}
 

--- a/jaeger_client/config.py
+++ b/jaeger_client/config.py
@@ -49,7 +49,7 @@ from .constants import (
 )
 from .metrics import LegacyMetricsFactory, MetricsFactory, Metrics
 from .utils import get_boolean, ErrorReporter
-from .codecs import B3Codec
+from .codecs import B3Codec, W3CTraceCodec
 
 DEFAULT_REPORTING_HOST = 'localhost'
 DEFAULT_REPORTING_PORT = 6831
@@ -315,6 +315,8 @@ class Config(object):
         if propagation == 'b3':
             # replace the codec with a B3 enabled instance
             return {Format.HTTP_HEADERS: B3Codec()}
+        if propagation == "w3c":
+            return {Format.HTTP_HEADERS: W3CTraceCodec()}
         return {}
 
     def throttler_group(self):

--- a/jaeger_client/span_context.py
+++ b/jaeger_client/span_context.py
@@ -16,19 +16,35 @@ from __future__ import absolute_import
 
 import opentracing
 
+from jaeger_client.trace_state import TraceState
+
 
 class SpanContext(opentracing.SpanContext):
     __slots__ = ['trace_id', 'span_id', 'parent_id', 'flags',
-                 '_baggage', '_debug_id']
+                 '_baggage', '_debug_id', 'operation_name', '_trace_state']
 
     """Implements opentracing.SpanContext"""
-    def __init__(self, trace_id, span_id, parent_id, flags, baggage=None, debug_id=None):
+    def __init__(self,
+                 trace_id,
+                 span_id,
+                 parent_id,
+                 flags,
+                 baggage=None,
+                 debug_id=None,
+                 operation_name=None,
+                 trace_state=None,
+    ):
         self.trace_id = trace_id
         self.span_id = span_id
         self.parent_id = parent_id or None
         self.flags = flags
         self._baggage = baggage or opentracing.SpanContext.EMPTY_BAGGAGE
         self._debug_id = debug_id
+        self.operation_name = operation_name
+        if isinstance(trace_state, TraceState):
+            self._trace_state = trace_state
+        else:
+            self._trace_state = TraceState(operation_name, span_id)
 
     @property
     def baggage(self):

--- a/jaeger_client/span_context.py
+++ b/jaeger_client/span_context.py
@@ -24,16 +24,9 @@ class SpanContext(opentracing.SpanContext):
                  '_baggage', '_debug_id', 'operation_name', '_trace_state']
 
     """Implements opentracing.SpanContext"""
-    def __init__(self,
-                 trace_id,
-                 span_id,
-                 parent_id,
-                 flags,
-                 baggage=None,
-                 debug_id=None,
-                 operation_name=None,
-                 trace_state=None,
-    ):
+    def __init__(self, trace_id, span_id, parent_id, flags,
+                 baggage=None, debug_id=None, operation_name=None,
+                 trace_state=None):
         self.trace_id = trace_id
         self.span_id = span_id
         self.parent_id = parent_id or None

--- a/jaeger_client/trace_state.py
+++ b/jaeger_client/trace_state.py
@@ -20,14 +20,10 @@ from six.moves import urllib_parse
 
 
 class TraceState(object):
-    __slots__ = ["_trace_state", "_encoder"]
+    __slots__ = ['_trace_state', '_encoder']
 
-    def __init__(self,
-                 operation_name=None,
-                 trace_id=None,
-                 header_values=None,
-                 encoder=None
-        ):
+    def __init__(self, operation_name=None, trace_id=None,
+                 header_values=None, encoder=None):
         self._trace_state = OrderedDict()
         self._encoder = encoder
         if header_values:
@@ -58,15 +54,8 @@ class TraceState(object):
         if self._encoder and skip_encode is False:
             value = self._encoder(value)
 
-        if six.PY2:
-            key = unicode(key)
-            value = unicode(value)
-        else:
-            key = str(key)
-            value = str(value)
-
-        key = six.ensure_str(key)
-        value = six.ensure_str(value)
+        key = six.ensure_str(str(key))
+        value = six.ensure_str(str(value))
 
         if sys.version_info >= (3, 2, 0):
             self._trace_state[key] = value
@@ -85,22 +74,25 @@ class TraceState(object):
                 link[1] = first
                 root[1] = first[0] = link
             else:
-                root[1] = first[0] = self._trace_state._OrderedDict__map[key] = [root, first, key]  # no_qa
+                root[1] = first[0] = self._trace_state._OrderedDict__map[key] = [root, first, key]
                 dict.__setitem__(self._trace_state, key, value)
 
     def get_formatted_header(self, url_parse=True):
         traces = []
         if not self._trace_state:
-            return ""
-        for key, value in six.iteritems(self._trace_state):
-            traces.append("{}={}".format(key, value))
+            return ''
+        for key, value in six.iteritems(
+                self._trace_state
+        ):
+            traces.append('{}={}'.format(key, value))
 
         header_traces = ','.join(traces)
         if url_parse is True:
             if six.PY2:
-                header_traces = urllib_parse.quote(header_traces.encode('utf-8'))
+                header_traces = urllib_parse.quote(
+                    header_traces.encode('utf-8'))
             else:
-                header_traces = urllib_parse.quote(header_traces)
+                header_traces = urllib_parse.quote(
+                    header_traces)
 
         return header_traces
-

--- a/jaeger_client/trace_state.py
+++ b/jaeger_client/trace_state.py
@@ -57,10 +57,7 @@ class TraceState(object):
         key = six.ensure_str(str(key))
         value = six.ensure_str(str(value))
 
-        if sys.version_info >= (3, 2, 0):
-            self._trace_state[key] = value
-            self._trace_state.move_to_end(key, last=False)
-        else:
+        if sys.version_info[0:3] < (3, 2, 0):
             # Not so graceful in older versions
             root = self._trace_state._OrderedDict__root  # noqa
             first = root[1]
@@ -74,8 +71,13 @@ class TraceState(object):
                 link[1] = first
                 root[1] = first[0] = link
             else:
-                root[1] = first[0] = self._trace_state._OrderedDict__map[key] = [root, first, key]
-                dict.__setitem__(self._trace_state, key, value)
+                self._trace_state._OrderedDict__map[key] = [root, first, key]  # noqa
+                first[0] = self._trace_state._OrderedDict__map[key]  # noqa
+                root[1] = first[0]
+                dict.__setitem__(self._trace_state, key, value)  # noqa
+        else:
+            self._trace_state[key] = value
+            self._trace_state.move_to_end(key, last=False)
 
     def get_formatted_header(self, url_parse=True):
         traces = []

--- a/jaeger_client/trace_state.py
+++ b/jaeger_client/trace_state.py
@@ -1,3 +1,15 @@
+# Copyright (c) 2020, The Jaeger Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+
 from __future__ import absolute_import
 
 from collections import OrderedDict
@@ -60,7 +72,7 @@ class TraceState(object):
             self._trace_state[key] = value
             self._trace_state.move_to_end(key, last=False)
         else:
-            # No so graceful in older versions
+            # Not so graceful in older versions
             root = self._trace_state._OrderedDict__root  # noqa
             first = root[1]
 

--- a/jaeger_client/trace_state.py
+++ b/jaeger_client/trace_state.py
@@ -1,0 +1,94 @@
+from __future__ import absolute_import
+
+from collections import OrderedDict
+
+import six
+import sys
+from six.moves import urllib_parse
+
+
+class TraceState(object):
+    __slots__ = ["_trace_state", "_encoder"]
+
+    def __init__(self,
+                 operation_name=None,
+                 trace_id=None,
+                 header_values=None,
+                 encoder=None
+        ):
+        self._trace_state = OrderedDict()
+        self._encoder = encoder
+        if header_values:
+            self.parse_from_header(header_values)
+        if operation_name and trace_id:
+            self.add(operation_name, trace_id)
+
+    def set_encoder(self, encoder=None):
+        self._encoder = encoder
+
+    def parse_from_header(self, value):
+        states = six.ensure_str(urllib_parse.unquote(value)).split(',')
+        states.reverse()
+        for state in states:
+            if '=' in state:
+                key, value = state.split('=', 1)
+                self.add(key, value, skip_encode=True)
+
+    def add(self, key, value=None, skip_encode=False):
+        if not key:
+            return
+        if not value:
+            value = self._trace_state.get(key, None)
+            skip_encode = True
+            if not value:
+                return
+
+        if self._encoder and skip_encode is False:
+            value = self._encoder(value)
+
+        if six.PY2:
+            key = unicode(key)
+            value = unicode(value)
+        else:
+            key = str(key)
+            value = str(value)
+
+        key = six.ensure_str(key)
+        value = six.ensure_str(value)
+
+        if sys.version_info >= (3, 2, 0):
+            self._trace_state[key] = value
+            self._trace_state.move_to_end(key, last=False)
+        else:
+            # No so graceful in older versions
+            root = self._trace_state._OrderedDict__root  # noqa
+            first = root[1]
+
+            if key in self._trace_state:
+                link = self._trace_state._OrderedDict__map[key]  # noqa
+                link_prev, link_next, _ = link
+                link_prev[1] = link_next
+                link_next[0] = link_prev
+                link[0] = root
+                link[1] = first
+                root[1] = first[0] = link
+            else:
+                root[1] = first[0] = self._trace_state._OrderedDict__map[key] = [root, first, key]  # no_qa
+                dict.__setitem__(self._trace_state, key, value)
+
+    def get_formatted_header(self, url_parse=True):
+        traces = []
+        if not self._trace_state:
+            return ""
+        for key, value in six.iteritems(self._trace_state):
+            traces.append("{}={}".format(key, value))
+
+        header_traces = ','.join(traces)
+        if url_parse is True:
+            if six.PY2:
+                header_traces = urllib_parse.quote(header_traces.encode('utf-8'))
+            else:
+                header_traces = urllib_parse.quote(header_traces)
+
+        return header_traces
+

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -28,7 +28,10 @@ from opentracing.ext import tags as ext_tags
 from opentracing.scope_managers import ThreadLocalScopeManager
 
 from . import constants
-from .codecs import TextCodec, ZipkinCodec, ZipkinSpanFormat, BinaryCodec, W3CTraceCodec, W3CTraceFormat
+from .codecs import (
+    TextCodec, ZipkinCodec, ZipkinSpanFormat,
+    BinaryCodec, W3CTraceCodec, W3CTraceFormat
+)
 from .span import Span, SAMPLED_FLAG, DEBUG_FLAG
 from .span_context import SpanContext
 from .metrics import Metrics, LegacyMetricsFactory

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -28,7 +28,7 @@ from opentracing.ext import tags as ext_tags
 from opentracing.scope_managers import ThreadLocalScopeManager
 
 from . import constants
-from .codecs import TextCodec, ZipkinCodec, ZipkinSpanFormat, BinaryCodec
+from .codecs import TextCodec, ZipkinCodec, ZipkinSpanFormat, BinaryCodec, W3CTraceCodec, W3CTraceFormat
 from .span import Span, SAMPLED_FLAG, DEBUG_FLAG
 from .span_context import SpanContext
 from .metrics import Metrics, LegacyMetricsFactory
@@ -82,6 +82,7 @@ class Tracer(opentracing.Tracer):
             ),
             Format.BINARY: BinaryCodec(),
             ZipkinSpanFormat: ZipkinCodec(),
+            W3CTraceFormat: W3CTraceCodec(),
         }
         if extra_codecs:
             self.codecs.update(extra_codecs)
@@ -205,7 +206,7 @@ class Tracer(opentracing.Tracer):
 
         span_ctx = SpanContext(trace_id=trace_id, span_id=span_id,
                                parent_id=parent_id, flags=flags,
-                               baggage=baggage)
+                               baggage=baggage, operation_name=operation_name)
         span = Span(context=span_ctx, tracer=self,
                     operation_name=operation_name,
                     tags=tags, start_time=start_time, references=valid_references)

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         'threadloop>=1,<2',
         'thrift',
         'tornado>=4.3',
+        'six>=1.15.0',
         'opentracing>=2.1,<3.0',
     ],
     # Uncomment below if need to test with unreleased version of opentracing

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -118,6 +118,9 @@ class ConfigTests(unittest.TestCase):
         c = Config({'propagation': 'b3'}, service_name='x')
         assert len(c.propagation) == 1
 
+        c = Config({'propagation': 'w3c'}, service_name='x')
+        assert len(c.propagation) == 1
+
     def test_throttler(self):
         c = Config({
             'throttler': {}

--- a/tests/test_span_context.py
+++ b/tests/test_span_context.py
@@ -15,11 +15,13 @@
 from __future__ import absolute_import
 
 from jaeger_client import SpanContext
+from jaeger_client.trace_state import TraceState
 
 
 def test_parent_id_to_none():
     ctx1 = SpanContext(trace_id=1, span_id=2, parent_id=0, flags=1)
     assert ctx1.parent_id is None
+    assert isinstance(ctx1._trace_state, TraceState)
 
 
 def test_with_baggage_items():

--- a/tests/test_trace_state.py
+++ b/tests/test_trace_state.py
@@ -1,3 +1,15 @@
+# Copyright (c) 2020, The Jaeger Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+
 import base64
 from collections import OrderedDict
 

--- a/tests/test_trace_state.py
+++ b/tests/test_trace_state.py
@@ -27,25 +27,27 @@ def test_basic_init():
 
 
 def test_add_trace():
-    trace_state = TraceState(operation_name="foo", trace_id="0123456789abcdef")
-    trace_state.add("bar", "testing")
-    trace_state.add("novalue")
+    trace_state = TraceState(operation_name='foo', trace_id='0123456789abcdef')
+    trace_state.add('bar', 'testing')
+    trace_state.add('novalue')
     trace_state.add(None)
-    assert trace_state._trace_state == OrderedDict([("bar", "testing"), ("foo", "0123456789abcdef")])
-    trace_state.add("foo")
-    assert trace_state._trace_state == OrderedDict([("foo", "0123456789abcdef"), ("bar", "testing")])
+    assert trace_state._trace_state == OrderedDict(
+        [('bar', 'testing'), ('foo', '0123456789abcdef')])
+    trace_state.add('foo')
+    assert trace_state._trace_state == OrderedDict(
+        [('foo', '0123456789abcdef'), ('bar', 'testing')])
 
 
 def test_add_trace_with_encoder():
     def encoder(value):
-        return six.ensure_str(base64.urlsafe_b64encode(value.encode('utf-8'))).rstrip("=")
+        return six.ensure_str(base64.urlsafe_b64encode(value.encode('utf-8'))).rstrip('=')
 
-    encoded = encoder("0123456789abcdef"), encoder("testing")
+    encoded = encoder('0123456789abcdef'), encoder('testing')
 
-    trace_state = TraceState(operation_name="foo", trace_id="0123456789abcdef", encoder=encoder)
-    trace_state.add("bar", "testing")
-    assert trace_state._trace_state["foo"] == encoded[0]
-    assert trace_state._trace_state["bar"] == encoded[1]
+    trace_state = TraceState(operation_name='foo', trace_id='0123456789abcdef', encoder=encoder)
+    trace_state.add('bar', 'testing')
+    assert trace_state._trace_state['foo'] == encoded[0]
+    assert trace_state._trace_state['bar'] == encoded[1]
 
 
 def test_set_encoder():
@@ -60,31 +62,31 @@ def test_set_encoder():
 
 def test_parse_from_header():
     trace_state = TraceState()
-    header_data = "foo=0123456789abcdef,bar=testing,test=qwerty,garbage"
+    header_data = 'foo=0123456789abcdef,bar=testing,test=qwerty,garbage'
     trace_state.parse_from_header(header_data)
     assert trace_state._trace_state == OrderedDict(
-        [("foo", "0123456789abcdef"), ("bar", "testing"), ("test", "qwerty")])
+        [('foo', '0123456789abcdef'), ('bar', 'testing'), ('test', 'qwerty')])
 
 
 def test_get_formatted_header():
     trace_state = TraceState()
-    assert trace_state.get_formatted_header() == ""
-    trace_state.add("foo", "0123456789abcdef")
-    trace_state.add("bar", "testing")
-    trace_state.add("test", "qwerty")
+    assert trace_state.get_formatted_header() == ''
+    trace_state.add('foo', '0123456789abcdef')
+    trace_state.add('bar', 'testing')
+    trace_state.add('test', 'qwerty')
     headers = trace_state.get_formatted_header(url_parse=False)
     formatted_headers = urllib_parse.quote(headers)
-    assert headers == "test=qwerty,bar=testing,foo=0123456789abcdef"
+    assert headers == 'test=qwerty,bar=testing,foo=0123456789abcdef'
     headers = trace_state.get_formatted_header()
     assert headers == formatted_headers
 
 
 def test_init_with_data():
     trace_state = TraceState(
-        operation_name="foo",
-        trace_id="0123456789abcdef",
-        header_values="bar=testing,test=qwerty,garbage"
+        operation_name='foo',
+        trace_id='0123456789abcdef',
+        header_values='bar=testing,test=qwerty,garbage'
     )
     assert len(trace_state._trace_state) == 3
     assert trace_state._trace_state == OrderedDict(
-        [("foo", "0123456789abcdef"), ("bar", "testing"), ("test", "qwerty")])
+        [('foo', '0123456789abcdef'), ('bar', 'testing'), ('test', 'qwerty')])

--- a/tests/test_trace_state.py
+++ b/tests/test_trace_state.py
@@ -1,0 +1,78 @@
+import base64
+from collections import OrderedDict
+
+import six
+
+from jaeger_client.trace_state import TraceState
+from six.moves import urllib_parse
+
+
+def test_basic_init():
+    trace_state = TraceState()
+    assert isinstance(trace_state, TraceState)
+    assert isinstance(trace_state._trace_state, OrderedDict)
+    assert trace_state._encoder is None
+
+
+def test_add_trace():
+    trace_state = TraceState(operation_name="foo", trace_id="0123456789abcdef")
+    trace_state.add("bar", "testing")
+    trace_state.add("novalue")
+    trace_state.add(None)
+    assert trace_state._trace_state == OrderedDict([("bar", "testing"), ("foo", "0123456789abcdef")])
+    trace_state.add("foo")
+    assert trace_state._trace_state == OrderedDict([("foo", "0123456789abcdef"), ("bar", "testing")])
+
+
+def test_add_trace_with_encoder():
+    def encoder(value):
+        return six.ensure_str(base64.urlsafe_b64encode(value.encode('utf-8'))).rstrip("=")
+
+    encoded = encoder("0123456789abcdef"), encoder("testing")
+
+    trace_state = TraceState(operation_name="foo", trace_id="0123456789abcdef", encoder=encoder)
+    trace_state.add("bar", "testing")
+    assert trace_state._trace_state["foo"] == encoded[0]
+    assert trace_state._trace_state["bar"] == encoded[1]
+
+
+def test_set_encoder():
+    def encoder(v):
+        return v
+
+    trace_state = TraceState()
+    assert trace_state._encoder is None
+    trace_state.set_encoder(encoder)
+    assert trace_state._encoder == encoder
+
+
+def test_parse_from_header():
+    trace_state = TraceState()
+    header_data = "foo=0123456789abcdef,bar=testing,test=qwerty,garbage"
+    trace_state.parse_from_header(header_data)
+    assert trace_state._trace_state == OrderedDict(
+        [("foo", "0123456789abcdef"), ("bar", "testing"), ("test", "qwerty")])
+
+
+def test_get_formatted_header():
+    trace_state = TraceState()
+    assert trace_state.get_formatted_header() == ""
+    trace_state.add("foo", "0123456789abcdef")
+    trace_state.add("bar", "testing")
+    trace_state.add("test", "qwerty")
+    headers = trace_state.get_formatted_header(url_parse=False)
+    formatted_headers = urllib_parse.quote(headers)
+    assert headers == "test=qwerty,bar=testing,foo=0123456789abcdef"
+    headers = trace_state.get_formatted_header()
+    assert headers == formatted_headers
+
+
+def test_init_with_data():
+    trace_state = TraceState(
+        operation_name="foo",
+        trace_id="0123456789abcdef",
+        header_values="bar=testing,test=qwerty,garbage"
+    )
+    assert len(trace_state._trace_state) == 3
+    assert trace_state._trace_state == OrderedDict(
+        [("foo", "0123456789abcdef"), ("bar", "testing"), ("test", "qwerty")])


### PR DESCRIPTION
Add a W3C Trace Context compatible codec. 
This includes support for the `traceparent` and `tracestate` headers.

Resolves #284.