### PR TITLE
Implement Binary codec

### DIFF
--- a/jaeger_client/codecs.py
+++ b/jaeger_client/codecs.py
@@ -140,7 +140,8 @@ class TextCodec(Codec):
 
 class BinaryCodec(Codec):
     """
-    Implements inject/extract of SpanContext to/from binary that compatible with golang implementation
+    Implements inject/extract of SpanContext to/from binary that compatible with golang
+    implementation
     https://github.com/jaegertracing/jaeger-client-go/blob/master/propagation.go#L177-L290
     Supports propagation of trace_id, span_id, flags and baggage
     """
@@ -156,7 +157,8 @@ class BinaryCodec(Codec):
             high = 0
             low = span_context.trace_id
         carrier += struct.pack('>QQQQBI', high, low, span_context.span_id or 0,
-                               span_context.parent_id or 0, span_context.flags, len(span_context.baggage))
+                               span_context.parent_id or 0, span_context.flags,
+                               len(span_context.baggage))
 
         for k, v in span_context.baggage.items():
             carrier += self._pack_baggage_item(k, v)
@@ -165,8 +167,10 @@ class BinaryCodec(Codec):
         if not isinstance(carrier, bytearray):
             raise InvalidCarrierException('carrier not a bytearray')
         baggage = {}
-        high_trace_id, low_trace_id, span_id, parent_id, flags, baggage_count = struct.unpack('>QQQQBI', carrier[:37])
-        # if high_trace_id isn't 0, then we are dealing with 128bit trace id integer, therefore unpack into 1 number
+        high_trace_id, low_trace_id, span_id, parent_id, flags, baggage_count = \
+            struct.unpack('>QQQQBI', carrier[:37])
+        # if high_trace_id isn't 0, then we are dealing with 128bit trace id integer,
+        # therefore unpack into 1 number
         if high_trace_id:
             trace_id = (high_trace_id << 64) | low_trace_id
         else:
@@ -207,7 +211,7 @@ class BinaryCodec(Codec):
         data_len = struct.unpack('>i', data[:4])[0]
         data_value = struct.unpack('>' + 'c' * data_len, data[4:4 + data_len])
         bytes_read = 4 + data_len
-        return b"".join(data_value).decode("utf-8"), bytes_read
+        return b''.join(data_value).decode('utf-8'), bytes_read
 
 
 def span_context_to_string(trace_id, span_id, parent_id, flags):

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -444,17 +444,14 @@ class TestCodecs(unittest.TestCase):
                  'baggage_count': 0,
                  'baggage': {}},
             b'a]\x85\xe0\xe0\x06\xd5[6k\x9d\x86\xaa\xbc\\\x8f#c\x06\x80jV\xdf\x826k\x9d\x86\xaa\xbc'
-            b'\\\x8f\x01\x00\x00\x00\x03\x00\x00\x00\x07key_one\x00\x00\x00\tvalue_one\x00\x00\x00'
-            b'\tkey_three\x00\x00\x00\x0bvalue_three\x00\x00\x00\x07key_two\x00\x00\x00\tvalue_two':
+            b'\\\x8f\x01\x00\x00\x00\x01\x00\x00\x00\x07key_one\x00\x00\x00\tvalue_one':
                 {'trace_id_high': 7015910995390813531,
                  'trace_id_low': 3921401102271798415,
                  'span_id': 2549888962631491458,
                  'parent_id': 3921401102271798415,
                  'flags': 1,
-                 'baggage_count': 3,
-                 'baggage': {'key_one': 'value_one',
-                             'key_two': 'value_two',
-                             'key_three': 'value_three'}
+                 'baggage_count': 1,
+                 'baggage': {'key_one': 'value_one'}
                  },
         }
 

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -409,6 +409,75 @@ class TestCodecs(unittest.TestCase):
         assert extracted_span_context.flags == span_context.flags
         assert extracted_span_context.baggage == span_context.baggage
 
+    def test_binary_codec_extract_compatibility_with_golang_client(self):
+        tracer = Tracer(
+            service_name='test',
+            reporter=InMemoryReporter(),
+            sampler=ConstSampler(True),
+        )
+        tests = {
+            b'\x00\x00\x00\x00\x00\x00\x00\x00u\x18\xa9\x13\xa0\xd2\xaf4u\x18\xa9\x13\xa0\xd2\xaf4'
+            b'\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00':
+                {'trace_id_high': 0,
+                 'trace_id_low': 8437679803646258996,
+                 'span_id': 8437679803646258996,
+                 'parent_id': None,
+                 'flags': 1,
+                 'baggage_count': 0,
+                 'baggage': {}},
+            b'K2\x88\x8b\x8f\xb5\x96\xe9+\xc6\xe6\xf5\x9d\xed\x8a\xd0+\xc6\xe6\xf5\x9d\xed\x8a\xd0'
+            b'\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00':
+                {'trace_id_high': 5418543434673002217,
+                 'trace_id_low': 3154462531610577616,
+                 'span_id': 3154462531610577616,
+                 'parent_id': None,
+                 'flags': 1,
+                 'baggage_count': 0,
+                 'baggage': {}},
+            b'd\xb7^Y\x1afI\x0bi\xe4lc`\x1e\xbep[\x0fw\xc8\x87\xfd\xb2Ti\xe4lc`\x1e\xbep\x01\x00'
+            b'\x00\x00\x00':
+                {'trace_id_high': 7257373061318854923,
+                 'trace_id_low': 7630342842742652528,
+                 'span_id': 6561594885260816980,
+                 'parent_id': 7630342842742652528,
+                 'flags': 1,
+                 'baggage_count': 0,
+                 'baggage': {}},
+            b'a]\x85\xe0\xe0\x06\xd5[6k\x9d\x86\xaa\xbc\\\x8f#c\x06\x80jV\xdf\x826k\x9d\x86\xaa\xbc'
+            b'\\\x8f\x01\x00\x00\x00\x03\x00\x00\x00\x07key_one\x00\x00\x00\tvalue_one\x00\x00\x00'
+            b'\tkey_three\x00\x00\x00\x0bvalue_three\x00\x00\x00\x07key_two\x00\x00\x00\tvalue_two':
+                {'trace_id_high': 7015910995390813531,
+                 'trace_id_low': 3921401102271798415,
+                 'span_id': 2549888962631491458,
+                 'parent_id': 3921401102271798415,
+                 'flags': 1,
+                 'baggage_count': 3,
+                 'baggage': {'key_one': 'value_one',
+                             'key_two': 'value_two',
+                             'key_three': 'value_three'}
+                 },
+        }
+
+        for span_context_serialized, expected in tests.items():
+            span_context = tracer.extract(Format.BINARY, bytearray(span_context_serialized))
+            # because python supports 128bit number as one number and go splits it in two 64 bit
+            # numbers, we need to split python number to compare it properly to go implementation
+            max_int64 = 0xFFFFFFFFFFFFFFFF
+            trace_id_high = (span_context.trace_id >> 64) & max_int64
+            trace_id_low = span_context.trace_id & max_int64
+
+            assert trace_id_high == expected['trace_id_high']
+            assert trace_id_low == expected['trace_id_low']
+            assert span_context.span_id == expected['span_id']
+            assert span_context.parent_id == expected['parent_id']
+            assert span_context.flags == expected['flags']
+            assert len(span_context.baggage) == expected['baggage_count']
+            assert span_context.baggage == expected['baggage']
+
+            carrier = bytearray()
+            tracer.inject(span_context, Format.BINARY, carrier)
+            assert carrier == bytearray(span_context_serialized)
+
 
 def test_default_baggage_without_trace_id(tracer):
     _test_baggage_without_trace_id(


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #224 

## Short description of the changes
Implements extract and inject method of the Binary codec to be able to
inject/extract span context to/from bytearray.

This commit implements binary context injection/extraction the same way as in jaeger-client for go. Inject method dumps span context into bytearray carrier and packs it in big endian order as follow:
8 bytes uint64 for first 8 bytes of trace id, 8 bytes uint64 for last 8 bytes of trace id, 8 bytes uint64 for span id, 8 bytes uint64 for parent id, 1 byte uint8 for flags, 4 bytes unit32 for number of baggage items.
If baggage exists, its packs it as follows:
4 bytes unit32 for number of bytes in key-name, key-name bytes, 4 bytes unit32 for number of bytes in value, value-bytes.
Extract method follows the same pattern.

Binary codec is compatible with golang jaeger-client implementation. 