### PR TITLE
Add package prefix to imports in generated code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ shell:
 
 # Generate jaeger thrifts
 THRIFT_GEN_DIR=jaeger_client/thrift_gen
+THRIFT_PACKAGE_PREFIX=jaeger_client.thrift_gen
 THRIFT_VER=0.9.3
 THRIFT_IMG=thrift:$(THRIFT_VER)
 THRIFT_PY_ARGS=new_style,tornado
@@ -100,7 +101,7 @@ thrift: idl-submodule thrift-image
 	set -e; \
 	for f in $$(find ${THRIFT_GEN_DIR} -iname '*.py'); do \
 	  echo fixing $$f; \
-	  awk -f thrift-gen-fix.awk $$f > tmp; \
+	  awk -f thrift-gen-fix.awk package_prefix=${THRIFT_PACKAGE_PREFIX} $$f > tmp; \
 	  mv tmp $$f; \
 	done
 

--- a/jaeger_client/__init__.py
+++ b/jaeger_client/__init__.py
@@ -16,11 +16,6 @@ from __future__ import absolute_import
 
 import sys
 
-# This is because thrift for python doesn't have 'package_prefix'.
-# The thrift compiled libraries refer to each other relative to their subdir.
-import jaeger_client.thrift_gen as modpath
-sys.path.append(modpath.__path__[0])
-
 __version__ = '4.5.1.dev0'
 
 from .tracer import Tracer  # noqa

--- a/jaeger_client/__init__.py
+++ b/jaeger_client/__init__.py
@@ -14,8 +14,6 @@
 
 from __future__ import absolute_import
 
-import sys
-
 __version__ = '4.5.1.dev0'
 
 from .tracer import Tracer  # noqa

--- a/jaeger_client/thrift_gen/agent/Agent.py
+++ b/jaeger_client/thrift_gen/agent/Agent.py
@@ -153,7 +153,7 @@ class emitZipkinBatch_args(object):
 
   thrift_spec = (
     None, # 0
-    (1, TType.LIST, 'spans', (TType.STRUCT,(zipkincore.ttypes.Span, zipkincore.ttypes.Span.thrift_spec)), None, ), # 1
+    (1, TType.LIST, 'spans', (TType.STRUCT,(jaeger_client.thrift_gen.zipkincore.ttypes.Span, jaeger_client.thrift_gen.zipkincore.ttypes.Span.thrift_spec)), None, ), # 1
   )
 
   def __init__(self, spans=None,):
@@ -173,7 +173,7 @@ class emitZipkinBatch_args(object):
           self.spans = []
           (_etype3, _size0) = iprot.readListBegin()
           for _i4 in xrange(_size0):
-            _elem5 = zipkincore.ttypes.Span()
+            _elem5 = jaeger_client.thrift_gen.zipkincore.ttypes.Span()
             _elem5.read(iprot)
             self.spans.append(_elem5)
           iprot.readListEnd()
@@ -227,7 +227,7 @@ class emitBatch_args(object):
 
   thrift_spec = (
     None, # 0
-    (1, TType.STRUCT, 'batch', (jaeger.ttypes.Batch, jaeger.ttypes.Batch.thrift_spec), None, ), # 1
+    (1, TType.STRUCT, 'batch', (jaeger_client.thrift_gen.jaeger.ttypes.Batch, jaeger_client.thrift_gen.jaeger.ttypes.Batch.thrift_spec), None, ), # 1
   )
 
   def __init__(self, batch=None,):
@@ -244,7 +244,7 @@ class emitBatch_args(object):
         break
       if fid == 1:
         if ftype == TType.STRUCT:
-          self.batch = jaeger.ttypes.Batch()
+          self.batch = jaeger_client.thrift_gen.jaeger.ttypes.Batch()
           self.batch.read(iprot)
         else:
           iprot.skip(ftype)

--- a/jaeger_client/thrift_gen/agent/ttypes.py
+++ b/jaeger_client/thrift_gen/agent/ttypes.py
@@ -9,8 +9,8 @@ import six
 from six.moves import xrange
 
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException
-import jaeger.ttypes
-import zipkincore.ttypes
+import jaeger_client.thrift_gen.jaeger.ttypes
+import jaeger_client.thrift_gen.zipkincore.ttypes
 
 
 from thrift.transport import TTransport

--- a/thrift-gen-fix.awk
+++ b/thrift-gen-fix.awk
@@ -11,5 +11,8 @@ BEGIN {six=0}
 {
     gsub(/from ttype/, "from .ttype", $0);
     gsub(/self.__dict__.iteritems\(\)/, "six.iteritems(self.__dict__)", $0);
+    if (package_prefix) {
+        $0 = gensub(/[[:alnum:]_]+\.ttypes/, package_prefix ".\\0", "g", $0);
+    }
     print
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #165

## Short description of the changes
- `thrift-gen-fix.awk` appends package prefix to all references to `*.ttypes` when variable `package_prefix` is set.