### PR TITLE
Specify minimal required python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ],
+    python_requires='>=3.5',
     install_requires=[
         'threadloop>=1,<2',
         'thrift',


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #311

## Short description of the changes
- Specify minimal required python version using `python_requires`, as suggested in linked issue. To completely resolve this issue, the current latest package (4.5.0) should be removed from PyPI
