### PR TITLE
Fix B3Codec's trace_id zero-padding for 32bit IDs

### DIFF
--- a/jaeger_client/codecs.py
+++ b/jaeger_client/codecs.py
@@ -336,7 +336,7 @@ class B3Codec(Codec):
 
     def __init__(self, generate_128bit_trace_id=False):
         self.generate_128bit_trace_id = generate_128bit_trace_id
-      
+
     def inject(self, span_context, carrier):
         if not isinstance(carrier, dict):
             raise InvalidCarrierException('carrier not a dictionary')

--- a/jaeger_client/codecs.py
+++ b/jaeger_client/codecs.py
@@ -334,10 +334,16 @@ class B3Codec(Codec):
     flags_header = 'X-B3-Flags'
     _flags_header_lc = flags_header.lower()
 
+    def __init__(self, generate_128bit_trace_id=False):
+        self.generate_128bit_trace_id = generate_128bit_trace_id
+        
     def inject(self, span_context, carrier):
         if not isinstance(carrier, dict):
             raise InvalidCarrierException('carrier not a dictionary')
-        carrier[self.trace_header] = format(span_context.trace_id, 'x').zfill(16)
+        if self.generate_128bit_trace_id:
+            carrier[self.trace_header] = format(span_context.trace_id, 'x').zfill(32)
+        else:
+            carrier[self.trace_header] = format(span_context.trace_id, 'x').zfill(16)
         carrier[self.span_header] = format(span_context.span_id, 'x').zfill(16)
         if span_context.parent_id is not None:
             carrier[self.parent_span_header] = format(span_context.parent_id, 'x').zfill(16)

--- a/jaeger_client/codecs.py
+++ b/jaeger_client/codecs.py
@@ -336,7 +336,7 @@ class B3Codec(Codec):
 
     def __init__(self, generate_128bit_trace_id=False):
         self.generate_128bit_trace_id = generate_128bit_trace_id
-        
+      
     def inject(self, span_context, carrier):
         if not isinstance(carrier, dict):
             raise InvalidCarrierException('carrier not a dictionary')

--- a/jaeger_client/config.py
+++ b/jaeger_client/config.py
@@ -314,7 +314,9 @@ class Config(object):
         propagation = self.config.get('propagation')
         if propagation == 'b3':
             # replace the codec with a B3 enabled instance
-            return {Format.HTTP_HEADERS: B3Codec()}
+            return {Format.HTTP_HEADERS: B3Codec(
+                generate_128bit_trace_id=self.generate_128bit_trace_id
+            )}
         return {}
 
     def throttler_group(self):

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -379,8 +379,8 @@ class TestCodecs(unittest.TestCase):
     def test_128bit_trace_id_with_zero_padding(self):
         codec = B3Codec(generate_128bit_trace_id=True)
 
-        carrier_1 = {'X-B3-SpanId': '39fe73de0012a0e5', "X-B3-ParentSpanId":"3dbf8a511e159b05",
-                   'X-B3-TraceId': '023f352eaefd8b887a06732f5312e2de', 'X-B3-Flags': '0'}
+        carrier_1 = {'X-B3-SpanId': '39fe73de0012a0e5', 'X-B3-ParentSpanId': '3dbf8a511e159b05',
+                     'X-B3-TraceId': '023f352eaefd8b887a06732f5312e2de', 'X-B3-Flags': '0'}
         span_context = codec.extract(carrier_1)
 
         carrier_2 = {}

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -376,6 +376,17 @@ class TestCodecs(unittest.TestCase):
         assert extracted.parent_id == ctx.parent_id
         assert extracted.flags == ctx.flags
 
+    def test_128bit_trace_id_with_zero_padding(self):
+        codec = B3Codec(generate_128bit_trace_id=True)
+
+        carrier_1 = {'X-B3-SpanId': '39fe73de0012a0e5', "X-B3-ParentSpanId":"3dbf8a511e159b05",
+                   'X-B3-TraceId': '023f352eaefd8b887a06732f5312e2de', 'X-B3-Flags': '0'}
+        span_context = codec.extract(carrier_1)
+
+        carrier_2 = {}
+        codec.inject(span_context=span_context, carrier=carrier_2)
+        assert carrier_1['X-B3-TraceId'] == carrier_2['X-B3-TraceId']
+
     def test_binary_codec(self):
         codec = BinaryCodec()
         with self.assertRaises(InvalidCarrierException):


### PR DESCRIPTION
## Which problem is this PR solving?
- Solve the problem of incorrect traceid injection when the traceid is 128bit and starts with 0

## Short description of the changes
For example, if the traceid is 023f352eaefd8b887a06732f5312e2de, it will inject as 23f352eaefd8b887a06732f5312e2de, which will cause the trace to split into two because the traceid is different

Signed-off-by: mizhexiaoxiao 1157861072@qq.com