### PR TITLE
In Jaeger Config, enable to add directly a sampler

### DIFF
--- a/jaeger_client/config.py
+++ b/jaeger_client/config.py
@@ -220,7 +220,7 @@ class Config(object):
     @property
     def sampler(self):
         sampler_param = self.config.get('sampler', {})
-        if isinstance(sampler_param , Sampler):
+        if isinstance(sampler_param, Sampler):
             return sampler_param
         sampler_type = sampler_param.get('type', None)
         sampler_param = sampler_param.get('param', None)

--- a/jaeger_client/config.py
+++ b/jaeger_client/config.py
@@ -33,7 +33,7 @@ from .sampler import (
     ProbabilisticSampler,
     RateLimitingSampler,
     RemoteControlledSampler,
-)
+    Sampler)
 from .constants import (
     DEFAULT_SAMPLING_INTERVAL,
     DEFAULT_FLUSH_INTERVAL,
@@ -219,9 +219,11 @@ class Config(object):
 
     @property
     def sampler(self):
-        sampler_config = self.config.get('sampler', {})
-        sampler_type = sampler_config.get('type', None)
-        sampler_param = sampler_config.get('param', None)
+        sampler_param = self.config.get('sampler', {})
+        if isinstance(sampler_param , Sampler):
+            return sampler_param
+        sampler_type = sampler_param.get('type', None)
+        sampler_param = sampler_param.get('param', None)
         if not sampler_type:
             return None
         elif sampler_type == SAMPLER_TYPE_CONST:

--- a/jaeger_client/config.py
+++ b/jaeger_client/config.py
@@ -219,11 +219,11 @@ class Config(object):
 
     @property
     def sampler(self):
-        sampler_param = self.config.get('sampler', {})
-        if isinstance(sampler_param, Sampler):
-            return sampler_param
-        sampler_type = sampler_param.get('type', None)
-        sampler_param = sampler_param.get('param', None)
+        sampler_config = self.config.get('sampler', {})
+        if isinstance(sampler_config, Sampler):
+            return sampler_config
+        sampler_type = sampler_config.get('type', None)
+        sampler_param = sampler_config.get('param', None)
         if not sampler_type:
             return None
         elif sampler_type == SAMPLER_TYPE_CONST:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,14 +13,18 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import unittest
+
 import opentracing.tracer
+
 from jaeger_client import Config, ConstSampler, ProbabilisticSampler, RateLimitingSampler
+from jaeger_client import constants
 from jaeger_client.config import DEFAULT_THROTTLER_PORT
 from jaeger_client.metrics import MetricsFactory
 from jaeger_client.reporter import NullReporter
-from jaeger_client import constants
+from tests.test_utils import TestSampler
 
 
 class ConfigTests(unittest.TestCase):
@@ -79,6 +83,11 @@ class ConfigTests(unittest.TestCase):
         c = Config({'sampler': {'type': 'bad-sampler'}}, service_name='x')
         with self.assertRaises(ValueError):
             c.sampler.is_sampled(0)
+
+    def test_object_sampler_sampler(self):
+        sampler = TestSampler()
+        c = Config({'sampler': sampler})
+        assert c.sampler is sampler
 
     def test_agent_reporting_host(self):
         c = Config({}, service_name='x')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -86,7 +86,7 @@ class ConfigTests(unittest.TestCase):
 
     def test_object_sampler_sampler(self):
         sampler = TestSampler()
-        c = Config({'sampler': sampler})
+        c = Config({'sampler': sampler}, service_name='x')
         assert c.sampler is sampler
 
     def test_agent_reporting_host(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,6 +18,7 @@ import mock
 import unittest
 
 from jaeger_client import utils
+from jaeger_client.sampler import Sampler
 
 
 class ConfigTests(unittest.TestCase):
@@ -43,10 +44,10 @@ class ConfigTests(unittest.TestCase):
     def test_get_None_boolean(self):
         self.check_boolean(None, 'qwer', False)
 
-#    def test_error_reporter_doesnt_send_metrics_if_not_configured(self):
-#        er = utils.ErrorReporter(False)
-#        er.error('foo', 1)
-#        assert not mock_metrics.count.called
+    #    def test_error_reporter_doesnt_send_metrics_if_not_configured(self):
+    #        er = utils.ErrorReporter(False)
+    #        er.error('foo', 1)
+    #        assert not mock_metrics.count.called
 
     def test_error_reporter_sends_metrics_if_configured(self):
         mock_metrics = mock.MagicMock()
@@ -81,3 +82,7 @@ def test_local_ip_does_not_blow_up():
 def test_get_local_ip_by_socket_does_not_blow_up():
     import jaeger_client.utils
     jaeger_client.utils.get_local_ip_by_socket()
+
+
+class TestSampler(Sampler):
+    pass


### PR DESCRIPTION
It can be useful when using a specific sampler that is not included in
this library (for example private sampler)

## Which problem is this PR solving?

https://github.com/jaegertracing/jaeger-client-python/issues/323

## Short description of the changes

Accept on Jaeger Config parameter sampler not only a dict but also a Sampler object
