### PR TITLE
Clean-up warnings

### DIFF
--- a/tests/test_crossdock.py
+++ b/tests/test_crossdock.py
@@ -50,7 +50,7 @@ def app():
 
 
 # noinspection PyShadowingNames
-@pytest.yield_fixture
+@pytest.fixture
 def tracer():
     tracer = Tracer(
         service_name='test-tracer',

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -96,7 +96,7 @@ class FakeMetricsFactory(LegacyMetricsFactory):
 
 
 class ReporterTest(AsyncTestCase):
-    @pytest.yield_fixture
+    @pytest.fixture
     def thread_loop(self):
         yield
 


### PR DESCRIPTION
```
tests/test_crossdock.py:54
  /home/runner/work/jaeger-client-python/jaeger-client-python/tests/test_crossdock.py:54: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
  Use @pytest.fixture instead; they are the same.
    def tracer():

tests/test_reporter.py:100
  /home/runner/work/jaeger-client-python/jaeger-client-python/tests/test_reporter.py:100: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
  Use @pytest.fixture instead; they are the same.
    def thread_loop(self):

```