### PR TITLE
Remove __future__ imports

### DIFF
--- a/crossdock/__init__.py
+++ b/crossdock/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 
 # This is because thrift for python doesn't have 'package_prefix'.
 # The thrift compiled libraries refer to each other relative to their subdir.

--- a/jaeger_client/TUDPTransport.py
+++ b/jaeger_client/TUDPTransport.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 import logging
 
 from thrift.transport.TTransport import TTransportBase

--- a/jaeger_client/__init__.py
+++ b/jaeger_client/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 
 __version__ = '4.6.2.dev0'
 

--- a/jaeger_client/codecs.py
+++ b/jaeger_client/codecs.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 
 import struct
 

--- a/jaeger_client/config.py
+++ b/jaeger_client/config.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 
 import logging
 import os

--- a/jaeger_client/constants.py
+++ b/jaeger_client/constants.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, unicode_literals, print_function
 
 from . import __version__
 

--- a/jaeger_client/ioloop_util.py
+++ b/jaeger_client/ioloop_util.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 
 import sys
 from tornado import gen

--- a/jaeger_client/local_agent_net.py
+++ b/jaeger_client/local_agent_net.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 
 from threadloop import ThreadLoop
 import tornado

--- a/jaeger_client/metrics/__init__.py
+++ b/jaeger_client/metrics/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 
 from .metrics import MetricsFactory  # noqa
 from .metrics import LegacyMetricsFactory  # noqa

--- a/jaeger_client/metrics/metrics.py
+++ b/jaeger_client/metrics/metrics.py
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-
-
 class MetricsFactory(object):
     """Generates new metrics."""
 

--- a/jaeger_client/reporter.py
+++ b/jaeger_client/reporter.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 
 import logging
 import threading

--- a/jaeger_client/sampler.py
+++ b/jaeger_client/sampler.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division
 
 import json
 import logging

--- a/jaeger_client/span.py
+++ b/jaeger_client/span.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 
 import threading
 import time

--- a/jaeger_client/span_context.py
+++ b/jaeger_client/span_context.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 
 import opentracing
 

--- a/jaeger_client/throttler.py
+++ b/jaeger_client/throttler.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division
 import json
 import logging
 import random

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 
 import socket
 

--- a/scripts/updateLicense.py
+++ b/scripts/updateLicense.py
@@ -1,6 +1,3 @@
-from __future__ import (
-    absolute_import, print_function, division, unicode_literals
-)
 
 import re
 import sys

--- a/tests/test_TUDPTransport.py
+++ b/tests/test_TUDPTransport.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 import unittest
 
 from jaeger_client.TUDPTransport import TUDPTransport

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 
 import unittest
 

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 
 import unittest
 from collections import namedtuple

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 
 import os
 import unittest

--- a/tests/test_crossdock.py
+++ b/tests/test_crossdock.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 
 import mock
 import json

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 
 import mock
 

--- a/tests/test_noop_tracer.py
+++ b/tests/test_noop_tracer.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-from __future__ import absolute_import
-
 import opentracing
 from opentracing import Tracer, Format
 

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 
 import logging
 import time

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import division
 import time
 import math
 import mock

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 
 import time
 import collections

--- a/tests/test_span_context.py
+++ b/tests/test_span_context.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 
 from jaeger_client import SpanContext
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 
 import mock
 import unittest


### PR DESCRIPTION
These imports are just not needed anymore, since we run on python 3.7+.
See here https://docs.python.org/3/library/__future__.html

Signed-off-by: Kai Mueller <15907922+kasium@users.noreply.github.com>