### PR TITLE
Add ipv6 support

### DIFF
--- a/tests/test_TUDPTransport.py
+++ b/tests/test_TUDPTransport.py
@@ -70,11 +70,15 @@ def test_created_socket_default_family():
             17, '', ('127.0.0.1', 12345)
         ),
         socket.AF_INET
+    ),
+    (
+        None,
+        TUDPTransport.DEFAULT_SOCKET_FAMILY
     )
-
 ))
 def test_created_socket_specified_family(addrinfo, expected_family):
-    with mock.patch('socket.getaddrinfo', return_value=[addrinfo]):
+    return_value = [addrinfo] if addrinfo else []
+    with mock.patch('socket.getaddrinfo', return_value=return_value):
         transport = TUDPTransport('ipv6-host', 12345)
         sock = transport._create_socket()
         assert sock.family == expected_family


### PR DESCRIPTION
Added ability to report spans to ipv6 only hosts using:
- config `local_agent.reporting_host_use_ipv6` option
- `JAEGER_AGENT_HOST_USE_IPV6` environment variable.
- if none of above options are not specified, jaeger client checks if host behind `reporting_host` is ipv6 only.

Resolves #337
